### PR TITLE
Adding a shadow to the home page dropdowns

### DIFF
--- a/_data/CONTRIBUTORS.yaml
+++ b/_data/CONTRIBUTORS.yaml
@@ -78,7 +78,7 @@ Ivan Mičetić:
     orcid: 0000-0003-1691-8425
 Robert Andrews:
     git: robertmand
-    email: andrewsr9@cardiff.ac.uk 
+    email: andrewsr9@cardiff.ac.uk
     orcid: 0000-0002-3491-2361
 Minna Ahokas:
     git: minnami
@@ -111,7 +111,10 @@ Priit Adler:
 Gregoire Rossier:
     Email: gregoire.rossier@sib.swiss
     Orcid: 0000-0002-0065-5053
-Alexander Botzki: 
+Alexander Botzki:
     git: abotzki
     email: alexander.botzki@vib.be
     orcid: 0000-0001-6691-4233
+Martin Cook:
+    git: martin-nc
+    email: martin.cook@elixir-europe.org  

--- a/css/customstyles.css
+++ b/css/customstyles.css
@@ -449,7 +449,7 @@ ul li::marker {
 .flexbox {
     display: flex;
     flex-direction: column;
-    margin-bottom: 250px;
+    margin-bottom: 75px;
 }
 
 .flexbox h2, .child-box a {
@@ -594,6 +594,7 @@ ul.accordion-panel li {
       position: absolute;
       left: -20px;
       margin-left: 20px;
+      box-shadow: 0px 8px 10px rgba(70, 70, 70, 0.5);
     }
 }
 
@@ -657,7 +658,7 @@ a.accordion-toggle, a.accordion-collapsed {
     flex-wrap: wrap;
     flex-direction: row;
     justify-content: space-around;
-    
+
 }
 
 .carousel-item.active,
@@ -731,7 +732,7 @@ a.accordion-toggle, a.accordion-collapsed {
         font-size: 0.7em;
         height: 22px;
     }
-    
+
     .item .hall-of-fame-hero img{
         width: 5em;
     }

--- a/css/customstyles.css
+++ b/css/customstyles.css
@@ -449,7 +449,7 @@ ul li::marker {
 .flexbox {
     display: flex;
     flex-direction: column;
-    margin-bottom: 75px;
+    margin-bottom: 80px;
 }
 
 .flexbox h2, .child-box a {

--- a/js/customscripts.js
+++ b/js/customscripts.js
@@ -61,7 +61,7 @@ document.addEventListener('DOMContentLoaded', () => {
         panel.style.maxHeight = null;
       } else {
         if ($(window).width() > 600) {
-          panel.style.maxHeight = "225px";
+          panel.style.maxHeight = "250px";
           panel.style.overflowY = "scroll";
           panel.style.width = panelWidth + "px";
         } else {


### PR DESCRIPTION
Adding shadows so they look better when overlapping the carousel. Preview here:
https://martin-nc.github.io/martinc-rdm-toolkit/

Not sure if we need more space between the buttons and carousel?

EDIT: I decided to add more space. Also made the dropdowns extend a little further.