### PR TITLE
Added quick-fix redirect to a secure url

### DIFF
--- a/_includes/landingpage.html
+++ b/_includes/landingpage.html
@@ -1,3 +1,8 @@
+<script>
+if (window.location.href = "https://rdm.elixir-europe.org") {
+  window.location.replace("https://rdmkit.elixir-europe.org");
+}
+</script>
 {%- assign sidebar = site.data.sidebars[page.sidebar] -%}
 <div class="blurb">
     <p>Are you working in the Life Sciences with data? Do you feel overwhelmed when you think about Research Data


### PR DESCRIPTION
A hacky line of Javascript that may fix the problem that when you go to https://rdm.elixir-europe.org you get a security warning ('Site not secure'), and a redirect doesn't happen. A more permanent fix has been requested.