### PR TITLE
Page without Title possible + info icon in tools & resource list

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -6,7 +6,7 @@
 <meta property="og:title" content="{{ site.site_title }}" />
 <meta property="og:description" content="{{ site.description }}" />
 <meta property="og:image" content="//rdmkit.elixir-europe.org/images/elixir_logo.png" />
-<title>{{ page.title }} | {{ site.site_title }}</title>
+<title>{%- if page.title %}{{ page.title }} | {{ site.site_title }} %}{%- else %}{{ site.site_title }}{%- endif %}</title>
 <!-- Syntax highlighting  -->
 <link rel="stylesheet" href="css/syntax.css">
 <!-- Icons -->

--- a/_includes/landingpage.html
+++ b/_includes/landingpage.html
@@ -1,15 +1,14 @@
 
 {%- assign sidebar = site.data.sidebars[page.sidebar] -%}
-<div class="blurb">
-    <p><b>Are you working in the Life Sciences with data? Do you feel overwhelmed when you think about Research Data
-        Management?</b></p>
-
-    <p>RDMKit is an online guide containing good data management practices applicable to research projects from the
-        beginning to the end. Developed and managed by people who work every day with life science data, RDMKit has
-        guidelines, information and pointers, organised in many different ways to help you with problems throughout
-        the data’s life cycle.</p>
-
+<div class="blurb-title">
+    Are you working in the Life Sciences with data? Do you feel overwhelmed when you think about Research Data Management?
 </div>
+<p>The ELIXIR Research Data Management Kit (RDMKit) is an online guide containing good data management practices applicable to research projects from the
+    beginning to the end. Developed and managed by people who work every day with life science data, RDMKit has
+    guidelines, information and pointers, organised in many different ways to help you with problems throughout
+    the data’s life cycle.
+</p>
+<br>
 
 <p class="centered mb-2"><strong>Find resources by clicking on the RDM data lifecycle</strong></p>
 <div class="embed-responsive embed-responsive-16by9 main_rdm">

--- a/_includes/toollist.html
+++ b/_includes/toollist.html
@@ -21,7 +21,11 @@ The tag "{{ include.tag }}" has not yet related tools or resources.
 <table class="tooltable display {%- if include.hide != true %} table-margin{%- endif %}">
     <thead>
         <tr>
-            <th>Tool or resource</th>
+            <th>Tool or resource {%- if include.tag or include.tag2 %}
+                <a href="#" data-toggle="tooltip" title="This is a curated list which means that not all tools or resources that exist for this topic are listed here. This is mainly because we do not intend to be a registry. In most cases you will only find back the tools or resources that are mentioned in this page.">
+                    <i class="fas fa-info-circle" style="color:var(--main-text-color);"></i>
+                </a>{%- endif %}
+            </th>
             <th>Description</th>
             <th>Tags</th>
             <th>Registry</th>

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -1,6 +1,7 @@
 ---
 layout: default
 ---
+{%- if page.title %}
 <div class="post-header">
     <h1 class="post-title-main">{{ page.title }}
         {%- if page.custom-editme %}
@@ -11,6 +12,7 @@ layout: default
         {%- endif %}
     </h1>
 </div>
+{%- endif %}
 <div class="post-content">
     {%- if page.summary %}
     <div class="summary">{{page.summary}}</div>

--- a/css/customstyles.css
+++ b/css/customstyles.css
@@ -798,11 +798,10 @@ a.accordion-toggle, a.accordion-collapsed {
     }
 }
 
-.blurb {
-    margin: 50px 0px;
-    background-color: var(--light-grey);
-    border-radius: 4px;
-    padding: 20px;
+.blurb-title {
+    font-size: 1.3em;
+    margin: 18px 0px;
+    font-weight: 600;
 }
 
 /* navgoco sidebar styles (customized) */

--- a/index.md
+++ b/index.md
@@ -1,6 +1,6 @@
 ---
-title: ELIXIR Research Data Management Kit
 toc: false
+search: exclude
 ---
 
 {% include landingpage.html %}

--- a/pages/your_domain/TEMPLATE_your_domain.md
+++ b/pages/your_domain/TEMPLATE_your_domain.md
@@ -17,7 +17,7 @@ In the event that no adequate Problem page exists for a problem that can be gene
 ## section 1 title
  
 ### Description
-<!--- Sections within Domain pages (aside from "Introduction" at the start and "Relevant Tools & Resources" at the end) should focus on particular data management problems, which should be described in this first sub-section.
+<!--- Sections within Domain pages (aside from "Introduction" at the start and "Relevant tools and resources " at the end) should focus on particular data management problems, which should be described in this first sub-section.
 For problems that are fully domain-specific, a detailed description is merited.
 For detailing the domain-specific challenges of a problem that is generic, please link to the corresponding generic Problem page before going into the domain-specific challenges. --->
 
@@ -32,7 +32,7 @@ For detailing the domain-specific challenges of a problem that is generic, pleas
 <!--- Add more sections as needed, with the same subsections as above. --->
 ...
 
-## Relevant tools & resources 
+## Relevant tools and resources  
 <!--- Automatically generated table; edit the TAG below to the tag for this page, so that tools that have this page's tag are listed here. You can get the tag for this page from the [list of tags](https://github.com/elixir-europe/rdmkit/blob/master/_data/tags.yml). If it isn't listed there, please raise an issue.--->
 
 {% include toollist.html tag="<!---TAG--->" %}

--- a/pages/your_domain/intrinsically_disordered_proteins.md
+++ b/pages/your_domain/intrinsically_disordered_proteins.md
@@ -50,6 +50,6 @@ Most common issues that you as a researcher can encounter during the mapping pro
 
   If there isn't an appropriate term in ontologies or vocabularies, you can submit a new proposal for community review at [DisProt feedback](https://disprot.org/feedback).
 
-## Relevant tools & resources
+## Relevant tools and resources 
 
 {% include toollist.html tag="IDP" %}

--- a/pages/your_domain/marine_metagenomics.md
+++ b/pages/your_domain/marine_metagenomics.md
@@ -42,7 +42,7 @@ The field of marine metagenomics has been in rapid expansion, with many statisti
 - Freely available software and pipelines, such as those listed below, can be an option compared to commercial analysis packages.
 - To get access to compute and storage you may contact your local IT department or national ELIXIR node which can guide you to the right facilities.
 
-## Relevant tools & resources 
+## Relevant tools and resources  
 <!--- Automatically generated table; edit the TAG below to the tag for this page, so that tools that have this page's tag are listed here. You can get the tag for this page from the [list of tags](https://github.com/elixir-europe/rdmkit/blob/master/_data/tags.yml). If it isn't listed there, please raise an issue.--->
 
 {% include toollist.html tag="marine" %}

--- a/pages/your_domain/microbial_biotechnology.md
+++ b/pages/your_domain/microbial_biotechnology.md
@@ -17,7 +17,7 @@ In the event that no adequate Problem page exists for a problem that can be gene
 ## Section 1 title
  
 ### Description
-<!--- Sections within Domain pages (aside from "Introduction" at the start and "Relevant Tools & Resources" at the end) should focus on particular data management problems, which should be described in this first sub-section.
+<!--- Sections within Domain pages (aside from "Introduction" at the start and "Relevant tools and resources " at the end) should focus on particular data management problems, which should be described in this first sub-section.
 For problems that are fully domain-specific, a detailed description is merited.
 For detailing the domain-specific challenges of a problem that is generic, please link to the corresponding generic Problem page before going into the domain-specific challenges. --->
 
@@ -32,7 +32,7 @@ For detailing the domain-specific challenges of a problem that is generic, pleas
 <!--- Add more sections as needed, with the same subsections as above. --->
 ...
 
-## Relevant tools & resources 
+## Relevant tools and resources  
 <!--- Automatically generated table; edit the TAG below to the tag for this page, so that tools that have this page's tag are listed here. You can get the tag for this page from the [list of tags](https://github.com/elixir-europe/rdmkit/blob/master/_data/tags.yml). If it isn't listed there, please raise an issue.--->
 
 {% include toollist.html tag="<!---TAG--->" %}

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -7,7 +7,7 @@ search: exclude
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   {% for page in site.pages -%}
   {% unless page.sitemap.exclude == true %}
-  {%- if page.title -%}
+  {%- if page.title or page.url == "/index.html"-%}
   <url>
     <loc>https://{{ site.url }}{{ page.url | remove: "index.html" }}</loc>
   </url>


### PR DESCRIPTION
Homepage without title:

![Screenshot from 2021-02-10 15-36-42](https://user-images.githubusercontent.com/44875756/107524328-f21a6200-6bb5-11eb-9f9c-4e4bb9c63b10.png)

Info icon in filtered tools table saynig: 


> This is a curated list which means that not all tools or resources that exist for this topic are listed here. This is mainly because we do not intend to be a registry. In most cases you will only find back the tools or resources that are mentioned in this page.


![Screenshot from 2021-02-10 15-37-06](https://user-images.githubusercontent.com/44875756/107524346-f5155280-6bb5-11eb-92ed-0825919ba94f.png)
