### PR TITLE
Description in page listing

### DIFF
--- a/_includes/pagelist.html
+++ b/_includes/pagelist.html
@@ -1,7 +1,7 @@
 <ul>
   {%- for page in site.pages %}{%- for tag in page.tags %}{% if tag == include.tag %}
   <li>
-    <a href="{{ page.url | remove: "/" }}">{{page.title}}</a>
+    <a href="{{ page.url | remove: "/" }}">{{page.title}}</a>{% if page.description %}: {{ page.description }}{% endif %}
   </li>
   {% endif %}{%- endfor %}{%- endfor %}
 </ul>

--- a/pages/your_problem/compliance_monitoring.md
+++ b/pages/your_problem/compliance_monitoring.md
@@ -2,6 +2,7 @@
 title: Compliance monitoring & measurement
 tags: [plan, researcher, data manager, policy officer] 
 contributors: [Christophe Trefois, Wei Gu, Pinar Alper]
+description: measure compliance to data management regulations and standards.
 ---
 
 ## How can data management capabilities be measured and documented?

--- a/pages/your_problem/data_analysis.md
+++ b/pages/your_problem/data_analysis.md
@@ -2,6 +2,7 @@
 title: Data analysis
 contributors: [Olivier Collin]
 tags: [analyse, process, reuse, researcher, IT support]
+description: how to make data analysis FAIR.
 ---
 
 ## What are the best practices for data analysis?

--- a/pages/your_problem/data_classification.md
+++ b/pages/your_problem/data_classification.md
@@ -3,6 +3,7 @@ title: Data classification
 keywords: [human data, data sensitivity]
 contributors: [Rob Hooft, Yvonne Kallberg, Pinar Alper, Markus Englund, Thanasis Vergoulis, Robert Andrews]
 tags: [share, collect, process, policy officer]
+description: how to identify different research data types.
 ---
 
 ## Is my data sensitive?

--- a/pages/your_problem/data_management_plan.md
+++ b/pages/your_problem/data_management_plan.md
@@ -3,6 +3,7 @@ title: Data management plan
 keywords: 
 contributors: [Flora D'Anna, Daniel Faria]
 tags: [plan, researcher, data manager, policy officer]
+description: how to write a Data Management Plan (DMP).
 ---
 
 

--- a/pages/your_problem/data_organisation.md
+++ b/pages/your_problem/data_organisation.md
@@ -3,6 +3,7 @@ title: Data organisation
 keywords: [file naming, versioning, folder structures]
 contributors: [Siiri Fuchs, Minna Ahokas, Yvonne Kallberg]
 tags: [collect, process, analyse, preserve, researcher, IT support, data manager]
+description: best practices to name and organise research data.
 ---
 
 ## What is the best way to name a file?

--- a/pages/your_problem/data_protection.md
+++ b/pages/your_problem/data_protection.md
@@ -3,6 +3,7 @@ title: Data protection
 contributors: [Pinar Alper]
 keywords: [gdpr, ethics]
 tags: [plan, preserve, share, IT support, policy officer, data manager]
+description: how to make research data compliant to GDPR.
 ---
 
 

--- a/pages/your_problem/data_publication.md
+++ b/pages/your_problem/data_publication.md
@@ -3,6 +3,7 @@ title: Data publication
 keywords: [deposition database, repository]
 contributors: [Munazah Andrabi, Ulrike Wittig, Elin Kronander]
 tags: [preserve, share, researcher, data manager]
+description: prepare data and find repositories for publication.
 ---
 
 

--- a/pages/your_problem/data_quality.md
+++ b/pages/your_problem/data_quality.md
@@ -3,6 +3,7 @@ title: Data quality
 keywords: [collecting]
 contributors: [Wei Gu, Pinar Alper]
 tags: [collect, process, researcher, data manager]
+description: ensure high quality research data.
 ---
 
 ## How can research data quality be ensured?

--- a/pages/your_problem/data_transfer.md
+++ b/pages/your_problem/data_transfer.md
@@ -1,7 +1,8 @@
 ---
 title: Data transfer
 keywords:
-tags: [preserve, share, reuse, IT support, data manager] 
+tags: [preserve, share, reuse, IT support, data manager]
+description: how to transfer data files.
 ---
 
 ## How to transfer large data files?

--- a/pages/your_problem/licensing.md
+++ b/pages/your_problem/licensing.md
@@ -3,6 +3,7 @@ title: Licensing
 keywords: 
 contributors: [Siiri Fuchs, Minna Ahokas, Nicola Soranzo, Rob Hooft]
 tags: [share, reuse, data manager, policy officer]
+description: how to license research data.
 ---
 
 ## Why should you assign a licence to your research data?

--- a/pages/your_problem/metadata_management.md
+++ b/pages/your_problem/metadata_management.md
@@ -3,6 +3,7 @@ title: Metadata management
 keywords: [ontology, vocabulary]
 contributors: [Flora D'Anna, Marco Carraro, Yvonne Kallberg, Markus Englund, Marco Roos]
 tags: [collect, preserve, share, researcher, data manager]
+description: ind metadata standards and vocabularies.
 ---
 
 ## How to find appropriate standard metadata for datasets or samples?

--- a/pages/your_problem/storage.md
+++ b/pages/your_problem/storage.md
@@ -2,7 +2,8 @@
 title: Data storage
 keywords: [archiving, computational resource, collaborative research, sharing]
 contributors: [Ulrike Wittig, Elin Kronander, Munazah Andrabi, Flora D'Anna, Flavio Licciulli, Ott Oopkaup, Marcus Lundberg, Thanasis Vergoulis, Frederik Coppens, Olivier Collin, Nadia Tonello, Korbinian Bösl]
-tags: [collect, analyse, preserve, share, IT support] 
+tags: [collect, analyse, preserve, share, IT support]
+description: how to find appropriate storage solutions.
 ---
 
 ## What features do I need in a storage solution when collecting data?

--- a/pages/your_role/researcher.md
+++ b/pages/your_role/researcher.md
@@ -30,19 +30,6 @@ I know the types and the approximate amount of data I will generate, but I have 
 
 ## Common issues
 
-Some common issues and solutions that researchers run into are listed here:
-* How do I know if my data is [sensitive](data_classification) and how to ensure [data protection](data_protection) and [compliance](compliance_monitoring)?
-* What are suitable resources for data computation and [storage](storage) during the project, considering size of data and who has access rights?
-* How do I best capture the [processes](data_analysis) involved in creating, processing and analysing my data?
-* What are best practices for [organising](data_organisation) my data?
-* How can I ensure research [data quality](data_quality)?
-* In which public repository should I [share](sharing) and [publish](data_publication) my data? 
-* How do I find appropriate standard [metadata](metadata_management) for my data?
-* What metadata and community standards do I need to [capture](collecting) to enable FAIR-publishing in public repositories?
-* What are the data retention policies for [my country](https://elixir-europe.org/about-us/how-funded/eu-projects/converge/wp1/dm-coordinators)?
-
-## Common issues
-
 {% include pagelist.html tag="researcher" %}
 
 ## Relevant tools and resources


### PR DESCRIPTION
This PR allows you to give pages a description in the metadata :

```
---
title: Compliance monitoring & measurement
tags: [plan, researcher, data manager, policy officer] 
contributors: [Christophe Trefois, Wei Gu, Pinar Alper]
description: description text
---
