### PR TITLE
Adding CSS for block quote

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -76,6 +76,14 @@ h1 {
     text-decoration: underline;
 }
 
+blockquote {
+    margin-left: 20px;
+    border-left: 5px solid var(--hover-grey);
+    padding-left: 10px;
+    color: var(--hover-grey);
+    border-radius: 4px;
+}
+
 hr {
     background: #999;
     margin-top: 80px;
@@ -144,7 +152,6 @@ pre code {
     padding: 0;
     font-size: inherit;
     color: inherit;
-    white-space: pre-wrap;
     background-color: transparent;
     border-radius: 0;
 }

--- a/pages/contribute/markdown_cheat_sheet.md
+++ b/pages/contribute/markdown_cheat_sheet.md
@@ -293,6 +293,28 @@ and are made with:
 
 ```
 
+## Block quotes
+
+You can add a blockquote using:
+
+```md
+> Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. 
+
+> Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+>
+> Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. 
+
+```
+
+Giving:
+
+> Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. 
+
+> Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+>
+> Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. 
+
+
 ## A collapsible piece of text
 
 <details>


### PR DESCRIPTION
Block quotes are supported by markdown using the greater than sign

```
> Test
```

![Screenshot from 2021-04-23 09-52-11](https://user-images.githubusercontent.com/44875756/115838814-58272f00-a41a-11eb-93a1-2de9ce5934ea.png)
