### PR TITLE
Fixing overflow of pagination in mobile

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -8,6 +8,7 @@
     <script type="text/javascript" charset="utf8" src="{{ 'assets/js/jquery.dataTables.min.js' | relative_url }}"></script>
     <script type="text/javascript" charset="utf8" src="{{ 'assets/js/dataTables.bootstrap5.min.js' | relative_url }}"></script>
     <script>
+        $.fn.DataTable.ext.pager.numbers_length = 5;
         $(document).ready(function () {
             $('div.datatable-begin').nextUntil('div.datatable-end', 'table').addClass('display');
             $('table.display').DataTable({
@@ -15,7 +16,6 @@
                 ordering:false,
                 stateSave: true,
                 searching: true,
-
             });
         });
     </script>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -15,7 +15,7 @@
                 lengthMenu: [ [25, 50, 100, -1], [25, 50, 100, "All"] ],
                 ordering:false,
                 stateSave: true,
-                searching: true,
+                searching: true
             });
         });
     </script>


### PR DESCRIPTION
This PR prevents the pagination of the all tools and resources table to be wider than the screen width. 