### PR TITLE
Events on front page

### DIFF
--- a/_data/events.yml
+++ b/_data/events.yml
@@ -1,7 +1,7 @@
 - name: Contentathon
   startDate: 2021-06-23
-  startTime: 9h00 CET 
+  startTime: '9:00'
   endDate: 2021-06-24
-  endTime: 13h30 CET
-  description: We would like to invite you to highlight your set of data management tools as a tool assembly in the RDMkit and describe how to use it, so others can do the same.
+  endTime: 13:30 CET
+  description: We would like to invite you to highlight your set of data management tools as a tool assembly in the RDMkit and describe how to use it, so others can do the same. (two half days)
   location: Online

--- a/_data/events.yml
+++ b/_data/events.yml
@@ -1,11 +1,7 @@
-- name: Contentathon Day 1
+- name: Contentathon
   startDate: 2021-06-23
   startTime: 9h00 CET 
   endDate: 2021-06-24
   endTime: 13h30 CET
   description: We would like to invite you to highlight your set of data management tools as a tool assembly in the RDMkit and describe how to use it, so others can do the same.
-  location: Zoom
-- name: Contentathon 2
-  startDate: 2021-08-23
-  description: Adding new tool assemblies to the RDMkit, it will be fun!
-  location: Zoom
+  location: Online

--- a/_data/events.yml
+++ b/_data/events.yml
@@ -3,5 +3,5 @@
   startTime: '9:00'
   endDate: 2021-06-24
   endTime: 13:30 CET
-  description: We would like to invite you to highlight your set of data management tools as a tool assembly in the RDMkit and describe how to use it, so others can do the same. (two half days)
+  description: We would like to invite you to highlight your set of data management tools as a tool assembly in the RDMkit and describe how to use it, so others can do the same (two half days).
   location: Online

--- a/_data/events.yml
+++ b/_data/events.yml
@@ -1,0 +1,11 @@
+- name: Contentathon Day 1
+  startDate: 2021-06-23
+  startTime: 9h00 CET 
+  endDate: 2021-06-24
+  endTime: 13h30 CET
+  description: We would like to invite you to highlight your set of data management tools as a tool assembly in the RDMkit and describe how to use it, so others can do the same.
+  location: Zoom
+- name: Contentathon 2
+  startDate: 2021-08-23
+  description: Adding new tool assemblies to the RDMkit, it will be fun!
+  location: Zoom

--- a/_includes/events.html
+++ b/_includes/events.html
@@ -1,0 +1,25 @@
+
+<div class="events">
+    <h3>Upcoming events</h3>
+    {%- assign events = site.data.events %}
+    <ul class="list-unstyled">
+        {%- for event in events %}
+        <li class='upcoming-event' data-start='{{ event.startDate}}'>
+        <span class="title mb-1">{{ event.name | escape }}</span>
+        <p class="text-muted mb-0"><i class="far fa-calendar me-2"></i><time datetime="{{ event.startDate | date: '%e %B, %Y %H:%M' }}">{{ event.startDate | date_to_long_string }} {{event.startTime}}</time>
+        {%- if event.end_date or event.endTime-%}- <time datetime="{{ event.endDate | date: '%e %B, %Y %H:%M %Z' }}">{{ event.endDate | date_to_long_string }} {{event.endTime}}</time>{% endif %}</p> 
+        {%- if event.location %}
+        <p class="text-muted mb-0"><i class="fas fa-map-marker-alt me-2"></i>{{ event.location }}</p> 
+        {%- endif %}
+        {%- if event.description %}
+        <p class="text-muted"><i class="fas fa-info me-2"></i>{{ event.description }}</p>
+        {%- endif %}
+        </li>
+        {%- endfor %}
+    </ul>
+</div>
+<script>
+  $(document).ready(function() {
+    showUpcomingEvents();
+  });
+</script>

--- a/_includes/events.html
+++ b/_includes/events.html
@@ -7,7 +7,7 @@
         <li class='upcoming-event' data-start='{{ event.startDate}}'>
         <span class="title mb-1">{{ event.name | escape }}</span>
         <p class="text-muted mb-0"><i class="far fa-calendar me-2"></i><time datetime="{{ event.startDate | date: '%e %B, %Y %H:%M' }}">{{ event.startDate | date_to_long_string }} {{event.startTime}}</time>
-        {%- if event.end_date or event.endTime-%}- <time datetime="{{ event.endDate | date: '%e %B, %Y %H:%M %Z' }}">{{ event.endDate | date_to_long_string }} {{event.endTime}}</time>{% endif %}</p> 
+        {%- if event.end_date or event.endTime-%} - <time datetime="{{ event.endDate | date: '%e %B, %Y %H:%M %Z' }}">{{ event.endDate | date_to_long_string }} {{event.endTime}}</time>{% endif %}</p> 
         {%- if event.location %}
         <p class="text-muted mb-0"><i class="fas fa-map-marker-alt me-2"></i>{{ event.location }}</p> 
         {%- endif %}

--- a/_includes/events.html
+++ b/_includes/events.html
@@ -2,7 +2,7 @@
 <div class="events">
     <h3>Upcoming events</h3>
     {%- assign events = site.data.events %}
-    <ul class="list-unstyled">
+    <ul class="list-unstyled mt-3">
         {%- for event in events %}
         <li class='upcoming-event' data-start='{{ event.startDate}}'>
         <span class="title mb-1">{{ event.name | escape }}</span>
@@ -12,7 +12,7 @@
         <p class="text-muted mb-0"><i class="fas fa-map-marker-alt me-2"></i>{{ event.location }}</p> 
         {%- endif %}
         {%- if event.description %}
-        <p class="text-muted"><i class="fas fa-info me-2"></i>{{ event.description }}</p>
+        <p class="text-muted">{{ event.description }}</p>
         {%- endif %}
         </li>
         {%- endfor %}

--- a/_includes/events.html
+++ b/_includes/events.html
@@ -7,7 +7,7 @@
         <li class='upcoming-event' data-start='{{ event.startDate}}'>
         <span class="title mb-1">{{ event.name | escape }}</span>
         <p class="text-muted mb-0"><i class="far fa-calendar me-2"></i><time datetime="{{ event.startDate | date: '%e %B, %Y %H:%M' }}">{{ event.startDate | date_to_long_string }} {{event.startTime}}</time>
-        {%- if event.end_date or event.endTime-%} - <time datetime="{{ event.endDate | date: '%e %B, %Y %H:%M %Z' }}">{{ event.endDate | date_to_long_string }} {{event.endTime}}</time>{% endif %}</p> 
+        {% if event.end_date or event.endTime %} - <time datetime="{{ event.endDate | date: '%e %B, %Y %H:%M %Z' }}">{{ event.endDate | date_to_long_string }} {{event.endTime}}</time>{% endif %}</p> 
         {%- if event.location %}
         <p class="text-muted mb-0"><i class="fas fa-map-marker-alt me-2"></i>{{ event.location }}</p> 
         {%- endif %}

--- a/_includes/landingpage.html
+++ b/_includes/landingpage.html
@@ -35,7 +35,7 @@
             .st0:hover,.st2:hover,.st3:hover,.st4:hover,.st5:hover,.st6:hover,.st7:hover {fill:#83858e;cursor: pointer;}
             text {pointer-events : none;}
           </style>
-          <a href="./planning" id="link-to-planning2" target="_top">
+          <a href="./planning" id="link-to-planning2" target="_top" title="planning">
             <g id="PlanPath2">
               <path class="st5" d="M144.4,31.6l-16.6,32.3c17.5,0.7,33.2,8.6,44,20.9l35.7-7l14.6-32.4C199.6,18.3,166,0.8,128.2,0L144.4,31.6z"
                 />
@@ -51,7 +51,7 @@
               <path class="st1" d="M175.8,38.6l0.1,0.1c0.7,0.7,1.3,1.3,2,2c-1,0.3-1.9,0.5-2.9,0.8C175.3,40.6,175.6,39.6,175.8,38.6z"/>
             </g>
           </a>
-          <a href="./collecting" id="link-to-collecting2" target="_top">
+          <a href="./collecting" id="link-to-collecting2" target="_top" title="collecting" >
             <g id="CollectPath2">
               <path class="st6" d="M213.9,159.8l34.4-8.7c1.7-8.3,2.6-16.8,2.6-25.6c0-28.5-9.5-54.7-25.4-75.8L210.8,82l-35.6,7
                 c7.5,10.2,11.9,22.8,11.9,36.4c0,3.7-0.3,7.3-1,10.8L213.9,159.8z"/>
@@ -65,7 +65,7 @@
                 C212.3,109.4,213.1,108.1,213.8,106.8z"/>
             </g>
           </a>
-          <a href="./processing" id="link-to-processing2" target="_top">
+          <a href="./processing" id="link-to-processing2" target="_top" title="processing">
             <g id="ProcessPath2">
               <path class="st4" d="M211.7,165L184,141.6c-4.4,16.4-15.5,30.1-30.1,38.1l-1.1,36.3l28.3,21.5c31.9-16.2,56-45.6,65-81.1L211.7,165
                 z"/>
@@ -90,7 +90,7 @@
                 c0.3-0.9,0.6-1.9,0.9-2.8c0.1-0.2,0.1-0.3,0.2-0.5C186.5,189,186.7,189,186.8,189z"/>
             </g>
           </a>
-          <a href="./analysing" id="link-to-analysing2" target="_top">
+          <a href="./analysing" id="link-to-analysing2" target="_top" title="analysing">
             <g id="AnalysePath2">
               <path class="st3" d="M149,218.3l1-36.2c-7.5,3.3-15.8,5.1-24.5,5.1c-8.5,0-16.6-1.7-24-4.9l-29.1,21.8l0.9,35.5
                 c15.9,7.3,33.6,11.4,52.2,11.4c18.4,0,36-4,51.7-11.1L149,218.3z"/>
@@ -105,7 +105,7 @@
                 c0-0.2,0-0.4,0.1-0.6C105.6,209,105.9,208.7,106.3,208.7z"/>
             </g>
           </a>
-          <a href="./preserving" id="link-to-preserving2" target="_top">
+          <a href="./preserving" id="link-to-preserving2" target="_top" title="preserving">
             <g id="PreservePath2">
               <path class="st2" d="M67.6,201.7l29-21.8c-14.7-7.8-25.8-21.4-30.4-37.8L31,133L3.8,155.8c8.8,35.5,32.8,65.1,64.7,81.4L67.6,201.7
                 z"/>
@@ -123,7 +123,7 @@
                 c-0.3-0.2-0.5-0.5-0.7-0.8c-0.1-0.3-0.1-0.6-0.1-0.8C38.9,167.4,38.9,166.1,38.9,164.8z"/>
             </g>
           </a>
-          <a href="./sharing" id="link-to-sharing2" target="_top">
+          <a href="./sharing" id="link-to-sharing2" target="_top" title="sharing">
             <g id="SharePath2">
               <path class="st7" d="M29.8,127.8l35.1,9c-0.7-3.7-1.1-7.5-1.1-11.4c0-13.4,4.3-25.9,11.6-36L60.6,56.3l-34.8-7
                 C9.6,70.4,0,96.8,0,125.5c0,8.6,0.9,17,2.5,25.1L29.8,127.8z"/>
@@ -138,7 +138,7 @@
                 C41.4,75.5,42,75.2,42.7,75z"/>
             </g>
           </a>
-          <a href="./reusing" id="link-to-reusing2" target="_top">
+          <a href="./reusing" id="link-to-reusing2" target="_top" title="reusing">
             <g id="ReusePath2">
               <path class="st0" d="M63.9,52.1l14.9,33.1c10.7-12.4,26.2-20.5,43.6-21.3l16.7-32.3L122.9,0C85.3,0.8,51.7,18.1,29.2,45L63.9,52.1z
                 "/>
@@ -224,6 +224,7 @@
   {%- endfor %}
 </div>
 
+{% include events.html %}
 
 <h3>We welcome contributors!</h3>
 <p>This project would not be possible without the many <a href="{{ '/contributors' | relative_url }}">amazing community contributors</a>. RDMkit is an open community project, and you are welcome to <a href="{{ '/how_to_contribute' | relative_url }}">join us</a>!</p>

--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -59,7 +59,7 @@
                             .st17:hover{fill:#9E51AD;cursor: pointer;}
                             text {pointer-events : none;}
                         </style>
-                        <a href="./planning" id="link-to-planning" target="_top">
+                        <a href="./planning" id="link-to-planning" target="_top" title="planning">
                             <g id="PlanPath">
                                 <path class="{{ planning }}"
                                     d="M144.4,31.6l-16.6,32.3c17.5,0.7,33.2,8.6,44,20.9l35.7-7l14.6-32.4C199.6,18.3,166,0.8,128.2,0L144.4,31.6z" />
@@ -77,7 +77,7 @@
                                     d="M175.8,38.6l0.1,0.1c0.7,0.7,1.3,1.3,2,2c-1,0.3-1.9,0.5-2.9,0.8C175.3,40.6,175.6,39.6,175.8,38.6z" />
                             </g>
                         </a>
-                        <a href="./collecting" id="link-to-collecting" target="_top">
+                        <a href="./collecting" id="link-to-collecting" target="_top" title="collecting">
                             <g id="CollectPath">
                                 <path class="{{ collecting }}" d="M213.9,159.8l34.4-8.7c1.7-8.3,2.6-16.8,2.6-25.6c0-28.5-9.5-54.7-25.4-75.8L210.8,82l-35.6,7
                                     c7.5,10.2,11.9,22.8,11.9,36.4c0,3.7-0.3,7.3-1,10.8L213.9,159.8z" />
@@ -91,7 +91,7 @@
                                     C212.3,109.4,213.1,108.1,213.8,106.8z" />
                             </g>
                         </a>
-                        <a href="./processing" id="link-to-processing" target="_top">
+                        <a href="./processing" id="link-to-processing" target="_top" title="processing">
                             <g id="ProcessPath">
                                 <path class="{{ processing }}" d="M211.7,165L184,141.6c-4.4,16.4-15.5,30.1-30.1,38.1l-1.1,36.3l28.3,21.5c31.9-16.2,56-45.6,65-81.1L211.7,165
                                     z" />
@@ -116,7 +116,7 @@
                                     c0.3-0.9,0.6-1.9,0.9-2.8c0.1-0.2,0.1-0.3,0.2-0.5C186.5,189,186.7,189,186.8,189z" />
                             </g>
                         </a>
-                        <a href="./analysing" id="link-to-analysing" target="_top">
+                        <a href="./analysing" id="link-to-analysing" target="_top" title="analysing">
                             <g id="AnalysePath">
                                 <path class="{{ analysing }}" d="M149,218.3l1-36.2c-7.5,3.3-15.8,5.1-24.5,5.1c-8.5,0-16.6-1.7-24-4.9l-29.1,21.8l0.9,35.5
                                     c15.9,7.3,33.6,11.4,52.2,11.4c18.4,0,36-4,51.7-11.1L149,218.3z" />
@@ -131,7 +131,7 @@
                                     c0-0.2,0-0.4,0.1-0.6C105.6,209,105.9,208.7,106.3,208.7z" />
                             </g>
                         </a>
-                        <a href="./preserving" id="link-to-preserving" target="_top">
+                        <a href="./preserving" id="link-to-preserving" target="_top" title="preserving">
                             <g id="PreservePath">
                                 <path class="{{ preserving }}" d="M67.6,201.7l29-21.8c-14.7-7.8-25.8-21.4-30.4-37.8L31,133L3.8,155.8c8.8,35.5,32.8,65.1,64.7,81.4L67.6,201.7
                                     z" />
@@ -149,7 +149,7 @@
                                     c-0.3-0.2-0.5-0.5-0.7-0.8c-0.1-0.3-0.1-0.6-0.1-0.8C38.9,167.4,38.9,166.1,38.9,164.8z" />
                             </g>
                         </a>
-                        <a href="./sharing" id="link-to-sharing" target="_top">
+                        <a href="./sharing" id="link-to-sharing" target="_top" title="sharing">
                             <g id="SharePath">
                                 <path class="{{ sharing }}" d="M29.8,127.8l35.1,9c-0.7-3.7-1.1-7.5-1.1-11.4c0-13.4,4.3-25.9,11.6-36L60.6,56.3l-34.8-7
                                     C9.6,70.4,0,96.8,0,125.5c0,8.6,0.9,17,2.5,25.1L29.8,127.8z" />
@@ -164,7 +164,7 @@
                                     C41.4,75.5,42,75.2,42.7,75z" />
                             </g>
                         </a>
-                        <a href="./reusing" id="link-to-reusing" target="_top">
+                        <a href="./reusing" id="link-to-reusing" target="_top" title="reusing">
                             <g id="ReusePath">
                                 <path class="{{ reusing }}" d="M63.9,52.1l14.9,33.1c10.7-12.4,26.2-20.5,43.6-21.3l16.7-32.3L122.9,0C85.3,0.8,51.7,18.1,29.2,45L63.9,52.1z
                                     " />

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -811,7 +811,7 @@ li ul .sidebar_rdm_sub {
 
 /* Events homepage */
 
-li.upcoming-event {
+li.upcoming-event, .events {
     display: none;
 }
 

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -808,3 +808,29 @@ li ul .sidebar_rdm_sub {
     text-decoration: none;
     color: var(--white-text);
 }
+
+li.upcoming-event {
+    display: none;
+}
+
+.events li {
+    border-left: var(--primary-theme-color) 5px solid;
+    border-radius: 4px;
+    padding-left: 11px;
+}
+
+.events i {
+    width: 20px;
+    text-align: center;
+}
+
+.events .title {
+    background-color: var(--main-text-color);
+    font-weight: 600;
+    color: white;
+    padding: 0px 11px;
+    border-radius: 0px 4px 4px 0px;
+    margin-left: -11px;
+    border: 1px solid var(--main-text-color);
+    display: inline-block;
+}

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -74,6 +74,20 @@ jQuery(function ($) {
 });
 
 
+/**
+ * Making relevant events visible
+ */
+ function nowToDateString() {
+  return new Date().toISOString().substring(0, 10);
+};
+
+function showUpcomingEvents() {
+  var dstr = nowToDateString();
+  var elements = $('li.upcoming-event').filter(function () {
+    return $(this).data('start') >= dstr;
+  });
+  elements.show();
+};
 
 /**
  * Search based on just the docs

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -83,9 +83,13 @@ jQuery(function ($) {
 
 function showUpcomingEvents() {
   var dstr = nowToDateString();
+  var events_block = $(document.getElementsByClassName("events"));
   var elements = $('li.upcoming-event').filter(function () {
     return $(this).data('start') >= dstr;
   });
+  if ($(elements).length > 0) {
+    events_block.show()
+  }
   elements.show();
 };
 

--- a/index.md
+++ b/index.md
@@ -5,5 +5,3 @@ layout: page
 ---
 
 {% include landingpage.html %}
-
-{% include events.html %}

--- a/index.md
+++ b/index.md
@@ -6,6 +6,8 @@ layout: page
 
 {% include landingpage.html %}
 
+{% include events.html %}
+
 ### Contributors
 This project would not be possible without the many [amazing community contributors](contributors). RDMkit is an open community project, and you are welcome to [join us](how_to_contribute)!
 

--- a/pages/contribute/editorial_board_guide.md
+++ b/pages/contribute/editorial_board_guide.md
@@ -89,6 +89,24 @@ If contributors make a pull request to make changes, by default the editors that
 When you make a pull request resolving an issue, it is possible to link this pull request to that specific issue. This can be easily done by writing in the conversation of the PR: `closes #number_of_issue`, or `fixes #number_of_issue` or even `resolves #number_of_issue`. This is definitely applicable when authors first open an issue announcing a change or requesting a new page, followed up by the pull request. 
 For more information about this topic please visit the [GitHub documentation page](https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
 
+## Adding a new event
+
+Add an event to the landing page by editing the `events.yml` in the `_data` directory in this repository. Use following attributes to define an event:
+
+
+```yml
+- name: Contentathon
+  startDate: 2021-06-23
+  startTime: '9:00'
+  endDate: 2021-06-24
+  endTime: 13:30 CET
+  description: We would like to invite you to highlight your set of data management tools as a tool assembly in the RDMkit and describe how to use it, so others can do the same. (two half days)
+  location: Online
+
+```
+
+Only name and startDate are mandatory attributes.
+
 ## Create a new page
 
 ### Simple way: using the GitHub interface
@@ -166,7 +184,7 @@ If the markdown page is named example_1.md, you can link towards it using:
 
 
 
-## Linking the GitHub accounts to the contributors
+## Adding extra info to the contributors
 
 Do you want that the GitHub picture of a contributor is shown next to their name? Or maybe you want that the name is clickable and links towards the GitHub page of that person? To enable this please add the name and the necessary metadata to the [CONTRIBUTORS.yaml](https://github.com/elixir-europe/rdmkit/blob/master/_data/CONTRIBUTORS.yaml) file in the *_data* directory like this:
 


### PR DESCRIPTION
This PR will add events to the frontpage. The events will only be visible when there are events upcoming.
Events are made visible using JavaScript so no new build of the website is needed. Info is taken from an events.yml file in the data directory.

![Screenshot from 2021-06-11 19-34-42](https://user-images.githubusercontent.com/44875756/121727448-367a2800-caec-11eb-9725-6a888bc06dbd.png)

A preview can be found here: https://bedroesb.github.io/rdmkit/