### PR TITLE
Local build using Docker

### DIFF
--- a/docker_startup.sh
+++ b/docker_startup.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-docker run -it --rm -p 4000:4000 -v $PWD:/srv/jekyll jekyll/jekyll:latest /bin/bash -c "chmod a+w /srv/jekyll/Gemfile.lock && chmod 777 /srv/jekyll && jekyll serve -w"

--- a/docker_startup.sh
+++ b/docker_startup.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+docker run -it --rm -p 4000:4000 -v $PWD:/srv/jekyll jekyll/jekyll:latest /bin/bash -c "chmod a+w /srv/jekyll/Gemfile.lock && chmod 777 /srv/jekyll && jekyll serve -w"

--- a/pages/contribute/working_with_git.md
+++ b/pages/contribute/working_with_git.md
@@ -60,11 +60,11 @@ To run the website locally, you can either use [Docker](https://www.docker.com/)
 
 ### Run using Docker
 
-1. If not already installed on your machine, install Docker. From the root of the ``rdmkit`` directory, run the following ``bash`` command :
+1. If not already installed on your machine, install Docker. From the root of the ``rdmkit`` directory, run:
     ```
-    ./docker_startup.sh
+    docker run -it --rm -p 4000:4000 -v $PWD:/srv/jekyll jekyll/jekyll:latest /bin/bash -c "chmod a+w /srv/jekyll/Gemfile.lock && chmod 777 /srv/jekyll && jekyll serve -w"
     ```
-If ``bash`` is not installed, open the script mentioned above, copy the Docker command and paste it into a terminal. This will start the docker container and serve the website locally.
+This will start the docker container and serve the website locally.
 
 ### Run using Jekyll directly
 

--- a/pages/contribute/working_with_git.md
+++ b/pages/contribute/working_with_git.md
@@ -60,11 +60,11 @@ To run the website locally, you can either use [Docker](https://www.docker.com/)
 
 ### Run using Docker
 
-1. If not already installed on your machine, install Docker. From the root of the ``rdmkit`` directory, run the following command:
+1. If not already installed on your machine, install Docker. From the root of the ``rdmkit`` directory, run the following ``bash`` command :
     ```
     ./docker_startup.sh
     ```
- 
+If ``bash`` is not installed, open the script mentioned above, copy the Docker command and paste it into a terminal. This will start the docker container and serve the website locally.
 
 ### Run using Jekyll directly
 

--- a/pages/contribute/working_with_git.md
+++ b/pages/contribute/working_with_git.md
@@ -50,32 +50,44 @@ NOTE: if you already did these steps in the past, start from the `git fetch upst
 
 The website is build on GitHub using Jekyll, a simple, static site generator based on ruby. When you have a local copy cloned onto your computer, it is possible to generate the website based on this repo. This makes it possible to preview changes live, every time you save a file from within the GitHub rdmkit repo. Follow these steps to deploy the website based on your local clone (copy) of the rdmkit repo:
 
-1. Make sure you have cloned the rdmkit repo
-    ```
+Make sure you have cloned the rdmkit repo:
+
     git clone git@github.com:USERNAME/rdmkit.git
     cd rdmkit
+
+
+To run the website locally, you can either use [Docker](https://www.docker.com/) or use Jekyll directly after installing various dependencies.
+
+### Run using Docker
+
+1. If not already installed on your machine, install Docker. From the root of the ``rdmkit`` directory, run the following command:
     ```
+    ./docker_startup.sh
+    ```
+ 
 
-2. If not already present on your machine, install ruby. Note that incompatibility issues may arise with ruby 3.0.0 (released 25.12.20) or newer versions.
+### Run using Jekyll directly
+
+1. If not already present on your machine, install ruby. Note that incompatibility issues may arise with ruby 3.0.0 (released 25.12.20) or newer versions.
 
 
-3. Install Jekyll
-If you’ve never installed or run a Jekyll site locally on your computer, follow these instructions to install Jekyll:
+1. Install Jekyll
+If you have never installed or run a Jekyll site locally on your computer, follow these instructions to install Jekyll:
    * Install Jekyll on MacOS/Ubuntu/Other_Linux/Windows: [https://jekyllrb.com/docs/installation/](https://jekyllrb.com/docs/installation/)
 
-4. Install Bundler and Jekyll
+1. Install Bundler and Jekyll
 
     ```
     gem install jekyll bundler
     ```
 
-5. Install dependencies
+1. Install dependencies
 
     ```
     bundle install
     ```
 
-6. deploy website
+1. deploy website
 
     ```
     bundle exec jekyll serve


### PR DESCRIPTION
This PR adds the option to run website locally in docker.
If you are like and do not want to install dependencies on your machine, docker is a suitable alternative

To test this PR
* Install Docker if not installed
* Run from the root directory ``./docker_startup.sh``.
* In your browser,  enter ``http://0.0.0.0:4000/``
* The website should be up
The instructions have been updated to include that option


<img width="1216" alt="Screenshot 2021-06-15 at 12 51 49" src="https://user-images.githubusercontent.com/1022396/122047832-800e8f80-cdd8-11eb-9f59-ab86e00ed79d.png">


cc @smza 