### PR TITLE
Replacing plus icons with arrows in sidepanel

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -358,18 +358,30 @@ pre code {
 
 .menu li>a>span {
     float: right;
-    font-size: 1.5em;
-    line-height: 1;
     width: 15px;
     text-align: center;
 }
 
 .menu li.active>a>span:after {
-    content: '-';
+    display: inline-block;
+    font-style: normal;
+    font-variant: normal;
+    text-rendering: auto;
+    -webkit-font-smoothing: antialiased;
+    font-family: "Font Awesome 5 Free";
+    font-weight: 900;
+    content: "\f077";
 }
 
 .menu li>a>span:after {
-    content: '+';
+    display: inline-block;
+    font-style: normal;
+    font-variant: normal;
+    text-rendering: auto;
+    -webkit-font-smoothing: antialiased;
+    font-family: "Font Awesome 5 Free";
+    font-weight: 900;
+    content: "\f078";
 }
 
 /*-----Summary under page title-----*/


### PR DESCRIPTION
Replacing the plus icons with arrows so it is not confused with filters in shopping websites

![Screenshot from 2021-06-29 14-21-48](https://user-images.githubusercontent.com/44875756/123797136-29c84300-d8e6-11eb-9b5a-1656c8d104b4.png)

