### PR TITLE
Adding Horizon Europe reference

### DIFF
--- a/pages/about/about.md
+++ b/pages/about/about.md
@@ -4,10 +4,20 @@ sidebar: about
 ---
 
 ## Who is the RDMkit for?
-The ELIXIR Research Data Management Kit (RDMkit) has been designed to guide life scientists in their efforts to better manage their research data following the FAIR Principles. It is based on the various steps of the data lifecycle, although not all the steps will be relevant to everyone. RDMkit can be navigated via ‘data life cycle’, ‘role’, ‘domain’, ‘problem’, ‘tools and resources’ and ‘tool assembly’. The contents are generated and maintained by the ELIXIR community coming together as part of the [ELIXIR-CONVERGE](https://elixir-europe.org/about-us/how-funded/eu-projects/converge) project.
+The ELIXIR Research Data Management Kit (RDMkit) has been designed to guide life scientists in their efforts to better manage their research data following the FAIR Principles. It is based on the various steps of the data lifecycle, although not all the steps will be relevant to everyone.
+
+The contents are generated and maintained by the ELIXIR community coming together as part of the [ELIXIR-CONVERGE](https://elixir-europe.org/about-us/how-funded/eu-projects/converge) project.
+
+<div class="card mt-4">
+  <div class="card-body">
+    <p class="card-text">RDMkit is recommended in the <a href="https://ec.europa.eu/info/funding-tenders/opportunities/docs/2021-2027/horizon/guidance/programme-guide_horizon_en.pdf">Horizon Europe Program Guide</a> as the "resource for Data Management guidelines and good practices for the Life Sciences."</p>
+  </div>
+</div>
 
 ## Why are the FAIR principles needed?
-At the heart of FAIR Science lies good data management practice. This is increasingly important as life science research becomes data-intensive and traditional ‘wet labs’ make space for ‘dry (computer) labs’. Having that in mind, the [FAIR Principles](https://www.nature.com/articles/sdata201618) were designed to improve the infrastructure supporting the reuse of research data. The intention of these principles is to act as a guide to improve the **F**indability, **A**ccessibility, **I**nteroperability and **R**euse of digital assets.
+At the heart of FAIR Science lies good data management practice. This is increasingly important as life science research becomes data-intensive and traditional ‘wet labs’ make space for ‘dry (computer) labs’.
+
+With that in mind, the [FAIR Principles](https://www.nature.com/articles/sdata201618) were designed to improve the infrastructure supporting the reuse of research data. The intention of these principles is to improve the **F**indability, **A**ccessibility, **I**nteroperability and **R**euse of digital assets.
 
 The increasing volume, complexity and speed of data creation made scientists rely on computational support exponentially. Therefore, the FAIR Principles place specific emphasis on enhancing the ability of machines to automatically find and use data, as well as supporting its reuse by other scientists, which facilitates knowledge discovery and improves research transparency.
 


### PR DESCRIPTION
Added a link to the [Horizon Europe program](https://ec.europa.eu/info/funding-tenders/opportunities/docs/2021-2027/horizon/guidance/programme-guide_horizon_en.pdf)  quote to the About page i.e. the RDMkit is "the "resource for Data Management guidelines and good practices for the Life Sciences."

Also split a couple of long paragraphs.