### PR TITLE
Registry badges update

### DIFF
--- a/_includes/page-metadata.html
+++ b/_includes/page-metadata.html
@@ -1,6 +1,6 @@
 {%- if page.tags != null %}
 <div class="meta-line p-3 mt-3">
-    <b>Pages that link to this page: </b>
+    <b>Related pages: </b>
     {%- for tag in page.tags | sort %}
     {%- assign related_page = site.pages | where:"page_tag",tag | first %}
     <a href="{{ related_page.url }}" class="meta-obj"

--- a/_includes/toollist.html
+++ b/_includes/toollist.html
@@ -10,7 +10,7 @@
 The tag "{{ include.tag }}" has not yet related tools or resources.
 {%- else%}
 <a class="visually-hidden-focusable" href='#skip-tool-table'>Skip tool table</a>
-<table id="tooltable" class="table table-hover display my-5">
+<table id="tooltable" class="table display my-5">
     <thead>
         <tr>
             <th>Tool or resource {%- if include.tag or include.tag2 -%}
@@ -20,7 +20,11 @@ The tag "{{ include.tag }}" has not yet related tools or resources.
             </th>
             <th>Description</th>
             <th>Related pages</th>
-            <th>Registry</th>
+            <th>Registry {%- if include.tag or include.tag2 -%}
+                <a data-bs-toggle="tooltip" data-bs-original-title="Links to related information in ELIXIR registries: related policies and standards in FAIRsharing, scientific and technical descriptions of the resource in bio.tools, and related training in TeSS.">
+                    <i class="fas fa-info-circle" style="color:var(--main-text-color);"></i>
+                </a>{%- endif %}
+            </th>
         </tr>
     </thead>
     <tbody>

--- a/_includes/toollist.html
+++ b/_includes/toollist.html
@@ -10,7 +10,7 @@
 The tag "{{ include.tag }}" has not yet related tools or resources.
 {%- else%}
 <a class="visually-hidden-focusable" href='#skip-tool-table'>Skip tool table</a>
-<table id="tooltable" class="display">
+<table id="tooltable" class="table table-hover display my-5">
     <thead>
         <tr>
             <th>Tool or resource {%- if include.tag or include.tag2 -%}
@@ -45,23 +45,23 @@ The tag "{{ include.tag }}" has not yet related tools or resources.
             <td style="text-align: center; vertical-align: middle;">
             {%- if tool.registry.biotools %}
             <a data-bs-toggle="tooltip"
-                data-bs-original-title="Bio.tools ID: {{tool.registry.biotools}}" href="https://bio.tools/{{tool.registry.biotools}}"
-                ><img style="background-color: orange;" class="registry_logo" src="{{ 'assets/img/bio.tools.svg' | relative_url }}" alt="bio.tools logo"/></a>
+                data-bs-original-title="" href="https://bio.tools/{{tool.registry.biotools}}"
+                ><span style="background-color: orange;" class="badge registry_logo">Bio.tools</span></a>
             {%- endif %}
             {%- if tool.registry.fairsharing %}
             <a data-bs-toggle="tooltip"
-                data-bs-original-title="FAIRsharing ID: {{tool.registry.fairsharing}}" href="https://fairsharing.org/FAIRsharing.{{tool.registry.fairsharing}}"
-                ><img style="background-color: #ECF0F1;" class="registry_logo" src="{{ 'assets/img/FAIRsharing-small.svg' | relative_url }}" alt="FAIRsharing logo"/></a>
+                data-bs-original-title="" href="https://fairsharing.org/FAIRsharing.{{tool.registry.fairsharing}}"
+                ><span style="background-color: #ECF0F1;" class="badge registry_logo">FAIRsharing</span></a>
             {%- endif %}
             {%- if tool.registry.fairsharing-coll %}
             <a data-bs-toggle="tooltip"
-                data-bs-original-title="FAIRsharing ID: {{tool.registry.fairsharing-coll}}" href="https://fairsharing.org/{{tool.registry.fairsharing-coll}}"
-                ><img style="background-color: #ECF0F1;" class="registry_logo" src="{{ 'assets/img/FAIRsharing-small.svg' | relative_url }}" alt="FAIRsharing logo"/></a>
+                data-bs-original-title="" href="https://fairsharing.org/{{tool.registry.fairsharing-coll}}"
+                ><span style="background-color: #ECF0F1;" class="badge registry_logo">FAIRsharing</span></a>
             {%- endif %}
             {%- if tool.registry.tess %}
             <a data-bs-toggle="tooltip"
-                data-bs-original-title="TeSS: {{tool.registry.tess}}" href="https://tess.elixir-europe.org/search?q={{tool.registry.tess}}" 
-                ><img style="background-color: #f47d20;" class="registry_logo" src="{{ 'assets/img/tess_logo.svg' | relative_url }}" alt="TeSS logo"/></a>
+                data-bs-original-title="" href="https://tess.elixir-europe.org/search?q={{tool.registry.tess}}" 
+                ><span style="background-color: #f47d20;" class="badge registry_logo">Training though TeSS</span></a>
             {%- endif %}
             </td> 
         </tr>

--- a/_includes/toollist.html
+++ b/_includes/toollist.html
@@ -50,22 +50,22 @@ The tag "{{ include.tag }}" has not yet related tools or resources.
             {%- if tool.registry.biotools %}
             <a data-bs-toggle="tooltip"
                 data-bs-original-title="" href="https://bio.tools/{{tool.registry.biotools}}"
-                ><span style="background-color: orange;" class="badge registry_logo">Bio.tools</span></a>
+                ><span class="badge registry_badge">Bio.tools</span></a>
             {%- endif %}
             {%- if tool.registry.fairsharing %}
             <a data-bs-toggle="tooltip"
                 data-bs-original-title="" href="https://fairsharing.org/FAIRsharing.{{tool.registry.fairsharing}}"
-                ><span style="background-color: #ECF0F1;" class="badge registry_logo">FAIRsharing</span></a>
+                ><span class="badge registry_badge">FAIRsharing</span></a>
             {%- endif %}
             {%- if tool.registry.fairsharing-coll %}
             <a data-bs-toggle="tooltip"
                 data-bs-original-title="" href="https://fairsharing.org/{{tool.registry.fairsharing-coll}}"
-                ><span style="background-color: #ECF0F1;" class="badge registry_logo">FAIRsharing</span></a>
+                ><span class="badge registry_badge">FAIRsharing</span></a>
             {%- endif %}
             {%- if tool.registry.tess %}
             <a data-bs-toggle="tooltip"
                 data-bs-original-title="" href="https://tess.elixir-europe.org/search?q={{tool.registry.tess}}" 
-                ><span style="background-color: #f47d20;" class="badge registry_logo">Training though TeSS</span></a>
+                ><span class="badge registry_badge">TeSS</span></a>
             {%- endif %}
             </td> 
         </tr>

--- a/_includes/toollist.html
+++ b/_includes/toollist.html
@@ -50,7 +50,7 @@ The tag "{{ include.tag }}" has not yet related tools or resources.
             {%- if tool.registry.biotools %}
             <a data-bs-toggle="tooltip"
                 data-bs-original-title="" href="https://bio.tools/{{tool.registry.biotools}}"
-                ><span class="badge registry_badge">Bio.tools</span></a>
+                ><span class="badge registry_badge">bio.tools</span></a>
             {%- endif %}
             {%- if tool.registry.fairsharing %}
             <a data-bs-toggle="tooltip"

--- a/_includes/toollist.html
+++ b/_includes/toollist.html
@@ -10,7 +10,7 @@
 The tag "{{ include.tag }}" has not yet related tools or resources.
 {%- else%}
 <a class="visually-hidden-focusable" href='#skip-tool-table'>Skip tool table</a>
-<table id="tooltable" class="table display my-5">
+<table id="tooltable" class="table display mb-5 mt-4">
     <thead>
         <tr>
             <th>Tool or resource {%- if include.tag or include.tag2 -%}

--- a/_includes/toollist.html
+++ b/_includes/toollist.html
@@ -49,22 +49,22 @@ The tag "{{ include.tag }}" has not yet related tools or resources.
             <td style="text-align: center; vertical-align: middle;">
             {%- if tool.registry.biotools %}
             <a data-bs-toggle="tooltip"
-                data-bs-original-title="" href="https://bio.tools/{{tool.registry.biotools}}"
+                data-bs-original-title="Find a scientific and technical description of the resource" href="https://bio.tools/{{tool.registry.biotools}}"
                 ><span class="badge registry_badge">bio.tools</span></a>
             {%- endif %}
             {%- if tool.registry.fairsharing %}
             <a data-bs-toggle="tooltip"
-                data-bs-original-title="" href="https://fairsharing.org/FAIRsharing.{{tool.registry.fairsharing}}"
+                data-bs-original-title="Find related policies and standards" href="https://fairsharing.org/FAIRsharing.{{tool.registry.fairsharing}}"
                 ><span class="badge registry_badge">FAIRsharing</span></a>
             {%- endif %}
             {%- if tool.registry.fairsharing-coll %}
             <a data-bs-toggle="tooltip"
-                data-bs-original-title="" href="https://fairsharing.org/{{tool.registry.fairsharing-coll}}"
+                data-bs-original-title="Find related policies and standards" href="https://fairsharing.org/{{tool.registry.fairsharing-coll}}"
                 ><span class="badge registry_badge">FAIRsharing</span></a>
             {%- endif %}
             {%- if tool.registry.tess %}
             <a data-bs-toggle="tooltip"
-                data-bs-original-title="" href="https://tess.elixir-europe.org/search?q={{tool.registry.tess}}" 
+                data-bs-original-title="Find training for this resource" href="https://tess.elixir-europe.org/search?q={{tool.registry.tess}}" 
                 ><span class="badge registry_badge">TeSS</span></a>
             {%- endif %}
             </td> 

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -464,8 +464,7 @@ pre code {
 /*-----Registries in tool table------*/
 
 .registry_badge {
-    font-weight: inherit;
-    background-color: var(--link-color);
+    background-color: var(--secondary-theme-color);
     color: var(--white-text);
 }
 

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -430,24 +430,15 @@ pre code {
 
 /*-----Table properties-----*/
 
-table {
+.table {
     display: block;
     overflow-x: auto;
     overflow-y: hidden;
+    border-color: var(--light-grey);
 }
 
-table, .dataTables_wrapper {
-    margin: 40px 0 20px;
-}
-
-table>tbody>tr>th, table>thead>tr>td, table>tbody>tr>td {
-    padding: 8px 8px 8px 0px;
-    line-height: 1.42857143;
-    border-top: 1px solid var(--light-grey);
-}
-
-table>thead>tr>th {
-    border-bottom: 2px solid var(--light-grey);
+.table>:not(:last-child)>:last-child>* {
+    border-bottom-color: inherit;
 }
 
 .default-badge {
@@ -461,20 +452,20 @@ table>thead>tr>th {
     background-color: var(--primary-theme-color);
 }
 
-/* name column bigger */
+/* name and description column bigger */
 
 #tooltable tr th:nth-child(1) {
     width: 25%;
 }
+#tooltable tr th:nth-child(2) {
+    width: 40%;
+}
 
 /*-----Registries in tool table------*/
 
-main img.registry_logo {
-    max-height: 40px;
-    max-width: 40px;
-    margin: 2px;
-    padding: 5px;
-    border-radius: 4px;
+.registry_logo {
+    color: var(--main-text-color);
+    font-weight: 400;
 }
 
 /*-----Footer-----*/

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -442,7 +442,7 @@ pre code {
     background-color: var(--primary-theme-color);
 }
 
-/*-----Table properties-----*/
+/*-----General table properties-----*/
 
 .table {
     display: block;
@@ -607,7 +607,6 @@ h2.card-title {
     float: right;
     width: 15px;
     text-align: center;
-    display: inline-block;
     font-style: normal;
     font-variant: normal;
     text-rendering: auto;
@@ -621,7 +620,6 @@ h2.card-title {
     float: right;
     width: 15px;
     text-align: center;
-    display: inline-block;
     font-style: normal;
     font-variant: normal;
     text-rendering: auto;

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -463,9 +463,14 @@ pre code {
 
 /*-----Registries in tool table------*/
 
-.registry_logo {
-    color: var(--main-text-color);
-    font-weight: 400;
+.registry_badge {
+    font-weight: inherit;
+    background-color: var(--link-color);
+    color: var(--white-text);
+}
+
+.registry_badge:hover {
+    background-color: var(--primary-theme-color);
 }
 
 /*-----Footer-----*/

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -193,6 +193,7 @@ pre code {
     position: relative;
     z-index: 2;
 }
+
 .search .fa-search {
     position: absolute;
     top: 12px;
@@ -213,7 +214,7 @@ pre code {
 }
 
 @media (max-width: 992px) {
-    .search-results{
+    .search-results {
         width: 100%;
     }
 }
@@ -428,6 +429,19 @@ pre code {
     list-style: circle outside;
 }
 
+/* ---- Theme Badges-------- */
+
+.default-badge {
+    font-weight: inherit;
+    background-color: var(--light-grey);
+    color: var(--main-text-color);
+}
+
+.default-badge:hover {
+    color: var(--white-text);
+    background-color: var(--primary-theme-color);
+}
+
 /*-----Table properties-----*/
 
 .table {
@@ -441,24 +455,22 @@ pre code {
     border-bottom-color: inherit;
 }
 
-.default-badge {
-    font-weight: inherit;
-    background-color: var(--light-grey);
-    color: var(--main-text-color);
-}
-
-.default-badge:hover {
-    color: var(--white-text);
-    background-color: var(--primary-theme-color);
-}
-
-/* name and description column bigger */
+/* Name and description column improvements */
 
 #tooltable tr th:nth-child(1) {
     width: 25%;
 }
+
 #tooltable tr th:nth-child(2) {
     width: 40%;
+}
+
+#tooltable td:nth-child(2) {
+    font-size: .9em
+}
+
+#tooltable td:nth-child(1) a {
+    font-weight: bold;
 }
 
 /*-----Registries in tool table------*/
@@ -508,6 +520,7 @@ footer .company-logo {
 }
 
 /*-----MetaData section -----*/
+
 .meta-line {
     background-color: var(--light-grey);
     border-radius: 4px;
@@ -748,6 +761,7 @@ h2.card-title {
 }
 
 /*--------------Custom classes--------------*/
+
 /* ---------------------------------------- */
 
 /* RDM wheel in sidebar */

--- a/pages/all_tools_and_resources.md
+++ b/pages/all_tools_and_resources.md
@@ -5,7 +5,7 @@ toc: false
 custom-editme: _data/main_tool_and_resource_list.csv
 ---
 
-This is the main tool and resource list of our website. This is a curated list which means that not all tools or resources that exist for a certain topic are listed here. This is mainly because we do not intend to be a registry. In most cases you will only find back the tools or resources that are mentioned in the different pages. Most pages will show a filtered list of this main table at the end of the page. If you see a missing link with one of the registries or a mistake, please open an [issue](https://github.com/elixir-europe/rdmkit/issues) or check our [how to add a tool or resource guide](tool_resource_update).
+This is the main tool and resource list of our website. This is a curated list which means that not all tools or resources that exist for a certain topic are listed here. This is mainly because we do not intend to be a registry. In most cases you will only find back the tools or resources that are mentioned in the different pages. Most pages will show a filtered list of this main table at the end of the page. We link to tools and resources to related information in ELIXIR registries: related policies and standards in FAIRsharing, scientific and technical descriptions of the resource in bio.tools, and related training in TeSS. If you see a missing link with one of the registries or a mistake, please open an [issue](https://github.com/elixir-europe/rdmkit/issues) or check our [how to add a tool or resource guide](tool_resource_update).
 
 
 {% include toollist.html %}


### PR DESCRIPTION
This part is a start to make the linking of tools to other registries more clear. The current look in the screenshot is not final and I need help in deciding what will be the text in the badge, and what will be the text when you hover over it. 

[Preview website](https://bedroesb.github.io/rdmkit/all_tools_and_resources.html)

![Screenshot from 2021-07-02 15-56-32](https://user-images.githubusercontent.com/44875756/124287193-07d1f900-db50-11eb-8724-6332d532546d.png)


@lauportell @korbinib @martin-nc 


TO DO:
- [x] 1. bio.tools has a lowercase 'b' at the beginning. Of course that's not usual in a proper noun, but there we are.
- [x] 2. I would make all the labels consistent, so they just name the resource: 'FAIRsharing', 'bio.tools' and 'TeSS'. Then when you hover over them you'd get: 'Find related policies and standards' (FAIRsharing), ' Find a scientific and technical description of the resource' (bio.tools) and 'Find training for this resource' (TeSS).
- [x] 3. I'm not sure about the label colours. I wouldn't know which orange applied to which resource, and orange is a warm colour so it jumps out. I'd be worried it jumped out more than the actual resource/tool name! Maybe they should all be the same colour, but a cooler one. Would the link blue work as a background? Or the dark grey or dark blue we have in the style guide (with contrast reversed)?
- [ ] 4. I'd make the [table heading sticky](https://css-tricks.com/position-sticky-and-table-headers/).
- [x] 5. I find the hover state on the rows distracting. I think the table rows are big enough for you to understand which one you are on. Maybe that's just my taste, though.