### PR TITLE
Improve DSW descriptions

### DIFF
--- a/_data/main_tool_and_resource_list.csv
+++ b/_data/main_tool_and_resource_list.csv
@@ -80,7 +80,7 @@ DNA Data Bank of Japan (DDBJ),https://www.ddbj.nig.ac.jp/index-e.html,A database
 Docker,https://www.docker.com/,"Docker is a software for the execution of applications in virtualized environments called containers. It is linked to DockerHub, a library for sharing container images",fairsharing-coll:bsg-d001254,"IT support, data analysis",
 DropBox,https://www.dropbox.com/?landing=dbv2,Cloud storage and file sharing service,,"storage, IT support, transfer",
 Dryad,https://datadryad.org/,"Open-source, community-led data curation, publishing, and preservation platform for CC0 publicly available research data",fairsharing:wkggtx,"data publication, biomol sim",
-DS-Wizard,https://ds-wizard.org/,Data Stewardship Wizard,biotools:Data_Stewardship_Wizard,"DMP, researcher, data manager, IT support, NeLS, TSD",
+Data Stewardship Wizard,https://ds-wizard.org/,Publicly available online tool for composing smart data management plans,biotools:Data_Stewardship_Wizard,"DMP, researcher, data manager, IT support, NeLS, TSD",
 Dynameomics,http://www.dynameomics.org/,Database of folding / unfolding pathway of representatives from all known protein folds by MD simulation,,biomol sim,
 e!DAL,https://edal.ipk-gatersleben.de/,Electronic data archive library is a framework for publishing and sharing research data,biotools:edal,"storage, IT support",
 e!DAL-PGP,https://edal-pgp.ipk-gatersleben.de/,Plant Genomics and Phenomics Research Data Repository,fairsharing:rf3m4g,"plants, researcher, data manager, IT support",

--- a/_data/tool_and_resource_list.yml
+++ b/_data/tool_and_resource_list.yml
@@ -687,9 +687,9 @@ Tools:
   tags:
   - data publication
   - biomol sim
-- description: Data Stewardship Wizard
+- description: Publicly available online tool for composing smart data management plans
   link: https://ds-wizard.org/
-  name: DS-Wizard
+  name: Data Stewardship Wizard
   registry:
     biotools: Data_Stewardship_Wizard
   tags:

--- a/pages/your_problem/data_management_plan.md
+++ b/pages/your_problem/data_management_plan.md
@@ -31,7 +31,7 @@ Moreover, there are ongoing efforts to develop templates for machine-actionable 
 
 ### Description
 DMPs can be written offline by using the downloaded template in a text document format.
-However, a number of web-based DMP tools are currently available that greatly facilitate the process, as they usually contain several DMP templates and provide guidance in interpreting and answering the questions.
+However, a number of web-based DMP tools are currently available that greatly facilitate the process, as they usually contain several DMP templates and provide guidance in interpreting and answering the questions. Some of the tools also allow collaboration on a DMP and track the progress as it is a *living document*.
 
 ### Considerations
 
@@ -42,12 +42,12 @@ However, a number of web-based DMP tools are currently available that greatly fa
 
 ### Solutions
 * Use the tool suggested by your funding agency or institution.
-* Choose one of the following online DMP tools:
-  * [DMPonline](https://dmponline.dcc.ac.uk): it is widely used in Europe and many universities or institutes provide a DMPonline instance to researchers.
-  * [DMP Canvas Generator](https://dmp.vital-it.ch/): this tool, mainly for researchers in Switzerland, is based on a questionnaire following the structure of the SNSF (Swiss National Science Foundation) instructions for DMP submission. Each Swiss High School can develop a specific template/canvas.
-  * [DMPTool](https://dmptool.org): it is widely used and many universities or institutes provide a DMPtool instance to researchers.
-  * [Data Stewardship Wizard (DSW)](https://demo.ds-wizard.org/dashboard): it is a tool to generate machine-actionable questionnaires based on existing or new templates (knowledge models).
-  * [EasyDMP](https://easydmp.no/login/): tool provided by the pan-European network EUDAT.
+* Choose one of the following online DMP tools (ordered alphabetically):
+  * [Data Stewardship Wizard (DSW)](https://ds-wizard.org): publicly available open-source tool to collaboratively compose data management plans through smart and customisable questionnaires with FAIRness evaluation.
+  * [DMP Canvas Generator](https://dmp.vital-it.ch): this tool, mainly for researchers in Switzerland, is based on a questionnaire following the structure of the SNSF (Swiss National Science Foundation) instructions for DMP submission. Each Swiss High School can develop a specific template/canvas.
+  * [DMPonline](https://dmponline.dcc.ac.uk): tool widely used in Europe and many universities or institutes provide a DMPonline instance to researchers.
+  * [DMPTool](https://dmptool.org): widely used tool and many universities or institutes provide a DMPTool instance to researchers.
+  * [EasyDMP](https://easydmp.no): tool provided by the pan-European network EUDAT.
 * Additional tools for creating a DMP are listed in the table below.
 
 


### PR DESCRIPTION
The descriptions of DSW were rather brief (e.g. title "DS-Wizard", description "Data Stewardship Wizard"). It was also not clear in what order are the tools listed - any other ordering is OK as well, just state what is the order. Finally, links for some tools headed to a landing page but for other to a login page or directly to a specific instance.