### PR TITLE
Support for news + events page

### DIFF
--- a/_data/news.yml
+++ b/_data/news.yml
@@ -1,0 +1,4 @@
+- name: Open Science FAIR
+  date: 2021-09-20
+  description: Test
+

--- a/_data/sidebars/about.yml
+++ b/_data/sidebars/about.yml
@@ -9,6 +9,10 @@ subitems:
         url: /editorial_board.html
       - title: Support
         url: /support.html
+  - title: News
+    url: /news.html
+  - title: Events
+    url: /events.html
   - title: Media kit
     url: /media_kit.html
   - title: Outreach

--- a/_includes/events.html
+++ b/_includes/events.html
@@ -1,6 +1,6 @@
 
-<div class="events">
-    <h3 class="mt-5">Upcoming events</h3>
+<div class="events upcoming-events">
+  <h2 class="mt-5 text-dark">Upcoming events</h2>
     {%- assign events = site.data.events %}
     <ul class="list-unstyled mt-3">
         {%- for event in events %}
@@ -12,11 +12,12 @@
           <p class="text-muted mb-0"><i class="fas fa-map-marker-alt me-2"></i>{{ event.location }}</p> 
           {%- endif %}
           {%- if event.description %}
-          <p class="text-muted">{{ event.description }}</p>
+          <p>{{ event.description }}</p>
           {%- endif %}
         </li>
         {%- endfor %}
     </ul>
+    <small>An overview of all our events can be fount on the <a href="/events.html">events page</a>.</small>
 </div>
 <script>
   $(document).ready(function() {

--- a/_includes/landingpage.html
+++ b/_includes/landingpage.html
@@ -226,11 +226,13 @@
 
 {% include events.html %}
 
-<h3 class="mt-5">We welcome contributors!</h3>
+{% include news.html limit=2 %}
+
+<h2 class="mt-5 text-dark">We welcome contributors!</h2>
 <p>This project would not be possible without the many <a href="{{ '/contributors' | relative_url }}">amazing community contributors</a>. RDMkit is an open community project, and you are welcome to <a href="{{ '/how_to_contribute' | relative_url }}">join us</a>!</p>
 
 
-<h3 class="mt-5">RDMkit in numbers</h3>
+<h2 class="mt-5 text-dark">RDMkit in numbers</h2>
 {%- assign contributors = site.data.CONTRIBUTORS %}
 {%- for page in site.pages %}
 {%- if page.contributors and page.search_exclude != true %}

--- a/_includes/news.html
+++ b/_includes/news.html
@@ -1,0 +1,23 @@
+
+<div class="news">
+    <h2 class="mt-5 text-dark">News</h2>
+    {%- assign news = site.data.news %}
+    {%- assign count = 0 %}
+    <ul class="list-unstyled mt-3">
+        {%- for new in news reversed%}
+        <li>
+          <span class="title mb-1">{{ new.name | escape }}</span>
+          <p class="text-muted mb-0"><i class="far fa-calendar me-2"></i><time>{{ new.date | date_to_long_string }}</time></p> 
+          {%- if new.description %}
+          <p>{{ new.description }}</p>
+          {%- endif %}
+        </li>
+        {%- assign count = count | plus: 1 %}
+        {%- if include.limit and count == include.limit %}
+        {%- break %}
+        {%- endif %}
+        {%- endfor %}
+    </ul>
+    <small>For more news please visit our <a href="/news.html">news page</a>.</small>
+</div>
+

--- a/_includes/news.html
+++ b/_includes/news.html
@@ -8,9 +8,7 @@
         <li>
           <span class="title mb-1">{{ new.name | escape }}</span>
           <p class="text-muted mb-0"><i class="far fa-calendar me-2"></i><time>{{ new.date | date_to_long_string }}</time></p> 
-          {%- if new.description %}
           <p>{{ new.description }}</p>
-          {%- endif %}
         </li>
         {%- assign count = count | plus: 1 %}
         {%- if include.limit and count == include.limit %}

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -646,25 +646,28 @@ li ul .sidebar_rdm_sub {
     }
 }
 
-/* Events homepage */
+/* Events and news homepage */
 
-li.upcoming-event,
+li.upcoming-event, li.past-event,
 .events {
     display: none;
 }
 
-.events li {
+.events li, .news li {
     border-left: $secondary 5px solid;
     border-radius: 4px;
-    padding-left: 11px;
+    padding: 0px 11px ;
+    border-bottom: 1px $gray-300 solid; 
+    border-right: 1px $gray-300 solid;
+    border-top: 1px $gray-300 solid;
 }
 
-.events i {
+.events i, .news i {
     width: 20px;
     text-align: center;
 }
 
-.events .title {
+.events .title, .news .title {
     background-color: $body-color;
     font-weight: 600;
     color: white;

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -94,7 +94,7 @@ function nowToDateString() {
 
 function showUpcomingEvents() {
   var dstr = nowToDateString();
-  var events_block = $(document.getElementsByClassName("events"));
+  var events_block = $(document.getElementsByClassName("upcoming-events"));
   var elements = $('li.upcoming-event').filter(function () {
     return $(this).data('start') >= dstr;
   });
@@ -103,6 +103,19 @@ function showUpcomingEvents() {
   }
   elements.show();
 };
+
+function showPastEvents() {
+  var dstr = nowToDateString();
+  var events_block = $(document.getElementsByClassName("past-events"));
+  var elements = $('li.past-event').filter(function () {
+    return $(this).data('start') < dstr;
+  });
+  if ($(elements).length > 0) {
+    events_block.show()
+  }
+  elements.show();
+};
+
 
 
 /** 

--- a/pages/about/events.md
+++ b/pages/about/events.md
@@ -1,0 +1,52 @@
+---
+title: Events
+sidebar: about
+---
+
+
+<div class="events upcoming-events">
+    <h2 class="mt-5">Upcoming events</h2>
+    {%- assign events = site.data.events %}
+    <ul class="list-unstyled mt-3">
+        {%- for event in events %}
+        <li class='upcoming-event' data-start='{{ event.startDate}}'>
+          <span class="title mb-1">{{ event.name | escape }}</span>
+          <p class="text-muted mb-0"><i class="far fa-calendar me-2"></i><time datetime="{{ event.startDate | date: '%e %B, %Y %H:%M' }}">{{ event.startDate | date_to_long_string }} {{event.startTime}}</time>
+          {% if event.endDate or event.endTime %} - <time datetime="{{ event.endDate | date: '%e %B, %Y %H:%M %Z' }}">{{ event.endDate | date_to_long_string }} {{event.endTime}}</time>{% endif %}</p> 
+          {%- if event.location %}
+          <p class="text-muted mb-0"><i class="fas fa-map-marker-alt me-2"></i>{{ event.location }}</p> 
+          {%- endif %}
+          {%- if event.description %}
+          <p class="text-muted">{{ event.description }}</p>
+          {%- endif %}
+        </li>
+        {%- endfor %}
+    </ul>
+</div>
+
+<div class="events past-events">
+    <h2 class="mt-5">Past events</h2>
+    {%- assign events = site.data.events %}
+    <ul class="list-unstyled mt-3">
+        {%- for event in events %}
+        <li class='past-event' data-start='{{ event.startDate}}'>
+          <span class="title mb-1">{{ event.name | escape }}</span>
+          <p class="text-muted mb-0"><i class="far fa-calendar me-2"></i><time datetime="{{ event.startDate | date: '%e %B, %Y %H:%M' }}">{{ event.startDate | date_to_long_string }} {{event.startTime}}</time>
+          {% if event.endDate or event.endTime %} - <time datetime="{{ event.endDate | date: '%e %B, %Y %H:%M %Z' }}">{{ event.endDate | date_to_long_string }} {{event.endTime}}</time>{% endif %}</p> 
+          {%- if event.location %}
+          <p class="text-muted mb-0"><i class="fas fa-map-marker-alt me-2"></i>{{ event.location }}</p> 
+          {%- endif %}
+          {%- if event.description %}
+          <p class="text-muted">{{ event.description }}</p>
+          {%- endif %}
+        </li>
+        {%- endfor %}
+    </ul>
+</div>
+<script>
+  $(document).ready(function() {
+    showPastEvents();
+    showUpcomingEvents();
+  });
+</script>
+

--- a/pages/about/news.md
+++ b/pages/about/news.md
@@ -1,0 +1,7 @@
+---
+title: News
+sidebar: about
+toc: false
+---
+
+{% include news.html %}

--- a/pages/contribute/editorial_board_guide.md
+++ b/pages/contribute/editorial_board_guide.md
@@ -132,6 +132,19 @@ Add an event to the landing page by editing the `events.yml` in the `_data` dire
 
 Only name and startDate are mandatory attributes.
 
+## Adding a news item
+
+Add a news item to the landing page by editing the `news.yml` in the `_data` directory in this repository. Use following attributes to define a news item:
+
+
+```yml
+- name: News title
+  date: 2021-06-23
+  description: A short description
+```
+
+All attributes are mandatory.
+
 ## Create a new page
 
 ### Simple way: using the GitHub interface


### PR DESCRIPTION
This PR will add the two latest news items to the frontpage + adds a dedicated events page with all past en upcoming events

![Screenshot from 2021-09-20 13-45-26](https://user-images.githubusercontent.com/44875756/134000696-c95c22a3-819b-4f71-bb31-2f519a72ae6b.png)
