### PR TITLE
Extract DSW deep link prefix to var

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -25,6 +25,9 @@ port: 4000
 gtag: G-RXQ55EFTTH
 # Google analytics tag
 
+dsw_deep_link_prefix: https://researchers.ds-wizard.org/knowledge-models/dsw:root:latest/preview?questionUuid=
+# prefix for DSW deep links to a certain question
+
 exclude:
   - .gitignore
   - CODEOWNERS

--- a/pages/your_tasks/storage.md
+++ b/pages/your_tasks/storage.md
@@ -43,7 +43,7 @@ When looking for solutions to store your data during the collection or generatio
 * Make sure to generate good documentation (i.e., README file) and metadata together with the data. Follow best practices for folder structure, file naming and versioning systems (see our Data Organisation page). Check if your institute provides a (meta)data management system, such as iRODS, DataVerse, FAIRDOM-SEEK or OSF. See All tools and resources table below for additional tools.
 
 ### Planning your data storage solution
-You can plan your data storage, including the above considerations and solutions, using the [Data Stewardship Wizard](https://researchers.ds-wizard.org/knowledge-models/dsw:root:latest/preview?questionUuid=a12aa967-28a5-4a9b-8df8-f7c533205ea4). This link provides access directly to the appropriate section of the Data Management Plan questionnaire.
+You can plan your data storage, including the above considerations and solutions, using the [Data Stewardship Wizard]({{ site.dsw_deep_link_prefix }}a12aa967-28a5-4a9b-8df8-f7c533205ea4). This link provides access directly to the appropriate section of the Data Management Plan questionnaire.
 
 ## How do you estimate computational resources for data processing and analysis?
 ### Description


### PR DESCRIPTION
With this, we can easily change the links in the future (e.g. when we have the intermediary "pick-your-DSW-instance/KM" page).

Jekyll/Liquid filter would be nicer and allow parameters but I think that is [not possible](https://docs.github.com/en/pages/setting-up-a-github-pages-site-with-jekyll/about-github-pages-and-jekyll#plugins) to get working with GitHub Pages (it would need to be a Ruby plugin). If it is possible, I can create the plugin...