### PR TITLE
Adding history button + tooltips

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -8,6 +8,8 @@ title: RDMkit
 # this appears in the html browser tab for the site title (seen mostly by search engines, not users)
 
 git_editme_path: https://github.com/elixir-europe/rdmkit/blob/master/
+
+git_history_path: https://github.com/elixir-europe/rdmkit/commits/master/
 # if you're using Github, provide the basepath to the branch you've created for reviews, following the sample here. if not, leave this value blank.
 
 description: "Find the answers to your Research Data Management questions in Life Sciences."

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -5,11 +5,14 @@ layout: default
     {%- if page.title %}
     <h1>{{ page.title }}
         {%- unless site.git_editme_path == nil %}
-        {%- if page.custom-editme %}
-        <a role="button" href="{{site.git_editme_path}}{{page.custom-editme}}" class="btn hover-primary text-primary btn-sm"><i class="fas fa-pencil-alt"></i> Edit me</a>
-        {%- else %}
-        <a role="button" href="{{site.git_editme_path}}{{page.path}}" class="btn hover-primary text-primary btn-sm"><i class="fas fa-pencil-alt"></i> Edit me</a>
-        {%- endif %}
+        <div class="btn-group">
+            {%- if page.custom-editme %}
+            <a role="button" data-bs-toggle="tooltip" title="Edit this page on GitHub" href="{{site.git_editme_path}}{{page.custom-editme}}" class="btn hover-primary text-primary"><i class="fas fa-pencil-alt"></i></a>
+            {%- else %}
+            <a role="button" data-bs-toggle="tooltip" title="Edit the content of this page on GitHub"  href="{{site.git_editme_path}}{{page.path}}" class="btn hover-primary text-primary"><i class="fas fa-pencil-alt"></i></a>
+            {%- endif %}
+            <a role="button" data-bs-toggle="tooltip" title="Check out the history of this page" href="{{site.git_history_path}}{{page.path}}" class="btn hover-primary text-primary"><i class="fas fa-history"></i></a>
+        </div>
         {%- endunless %}
     </h1>
     {%- endif %}

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -7,9 +7,9 @@ layout: default
         {%- unless site.git_editme_path == nil %}
         <div class="btn-group">
             {%- if page.custom-editme %}
-            <a role="button" data-bs-toggle="tooltip" title="Edit this page on GitHub" href="{{site.git_editme_path}}{{page.custom-editme}}" class="btn hover-primary text-primary"><i class="fas fa-pencil-alt"></i></a>
+            <a role="button" data-bs-toggle="tooltip" title="Propose changes to this page on GitHub" href="{{site.git_editme_path}}{{page.custom-editme}}" class="btn hover-primary text-primary"><i class="fas fa-pencil-alt"></i></a>
             {%- else %}
-            <a role="button" data-bs-toggle="tooltip" title="Edit the content of this page on GitHub"  href="{{site.git_editme_path}}{{page.path}}" class="btn hover-primary text-primary"><i class="fas fa-pencil-alt"></i></a>
+            <a role="button" data-bs-toggle="tooltip" title="Propose changes to the content of this page on GitHub"  href="{{site.git_editme_path}}{{page.path}}" class="btn hover-primary text-primary"><i class="fas fa-pencil-alt"></i></a>
             {%- endif %}
             <a role="button" data-bs-toggle="tooltip" title="Check out the history of this page" href="{{site.git_history_path}}{{page.path}}" class="btn hover-primary text-primary"><i class="fas fa-history"></i></a>
         </div>


### PR DESCRIPTION
Next to the edit me button we will also have a history button.

This can be with or without text:
![Screenshot from 2021-11-24 14-31-25](https://user-images.githubusercontent.com/44875756/143251310-f64a212a-8c81-4164-bfdc-7f30e0772638.png)
![Screenshot from 2021-11-24 14-45-08](https://user-images.githubusercontent.com/44875756/143251326-eb610300-920f-4c65-9c18-59e979c7602e.png)
![Screenshot from 2021-11-24 14-52-00](https://user-images.githubusercontent.com/44875756/143251338-0d09d72c-7648-4464-9687-e94835a42382.png)

