### PR TITLE
`how_to_access` field visualized in the description of the tool

### DIFF
--- a/_includes/navigation-tiles.html
+++ b/_includes/navigation-tiles.html
@@ -95,11 +95,16 @@
                     <span class="me-2"><b><small>Affiliations:</small></b></span>
                     {%- for affiliation in current_page.affiliations %}
                     {%- assign filter_affiliation = alllogos | where: "name", affiliation %}
-                    {%- if affiliation.size == 2 %}
                     {%- assign country = affiliation | upcase %}
+                    {%- if affiliation.size == 2 %}
+                    {%- assign country_link = site.pages | where:"country_code",country | first %}
+                    {%- if country_link %}
+                    <a role="button" href="{{country_link.url}}" data-bs-toggle="tooltip" title="{{allcountries[country]}}" class="btn btn-sm bg-white hover-primary"><div class="flag-icon flag-icon-{{affiliation | downcase}} h-30px"></div></a>
+                    {%- else %}
                     <span class="d-inline-block" tabindex="0" data-bs-toggle="tooltip" title="{{allcountries[country]}}">
                         <button class="btn btn-sm text-dark bg-white pe-none" title="{{allcountries[country]}}"><div class="flag-icon flag-icon-{{affiliation | downcase}} h-30px"></div></button>
                     </span>
+                    {%- endif %}
                     {%- elsif affiliation == "ALL" %}
                     <span class="d-inline-block" tabindex="0" data-bs-toggle="tooltip" title="All people">
                         <button class="btn btn-sm text-dark bg-white pe-none" title="ALL"><div class="h-30px">ALL</div></button>
@@ -118,10 +123,15 @@
                     {%- for audience in current_page.audience %}
                     {%- assign filter_audience = alllogos | where: "name", audience %}
                     {%- if audience.size == 2 %}
-                    {%- assign country = audience | upcase  %}
+                    {%- assign country = audience | upcase %}
+                    {%- assign country_link = site.pages | where:"country_code",country | first %}
+                    {%- if country_link %}
+                    <a role="button" href="{{country_link.url}}" data-bs-toggle="tooltip" title="{{allcountries[country]}}" class="btn btn-sm bg-white hover-primary"><div class="flag-icon flag-icon-{{audience | downcase}} h-30px"></div></a>
+                    {%- else %}
                     <span class="d-inline-block" tabindex="0" data-bs-toggle="tooltip" title="{{allcountries[country]}}">
                         <button class="btn btn-sm text-dark bg-white pe-none" title="{{allcountries[country]}}"><div class="flag-icon flag-icon-{{audience | downcase}} h-30px"></div></button>
                     </span>
+                    {%- endif %}
                     {%- elsif audience == "ALL" %}
                     <span class="d-inline-block" tabindex="0" data-bs-toggle="tooltip" title="All people">
                         <button class="btn btn-sm text-dark bg-white pe-none" title="ALL"><div class="h-30px">ALL</div></button>

--- a/_includes/resource-listing.html
+++ b/_includes/resource-listing.html
@@ -19,11 +19,21 @@
             {%- for tool in tools | sort %}
             <tr>
                 {% if tool.url %}
-                <td><a href="{{tool.url}}">{{tool.name}}</a></td>
+                <td><a href="{{tool.url}}">{{tool.name}}</a>
+                </td>
                 {%- else %}
                 <td>{{tool.name}}</td>
                 {%- endif %}
-                <td>{{tool.description}}</td>
+                <td>{{tool.description}}
+                    {%- if tool.instance_of or tool.how_to_access %}
+                    <div class="d-block">
+                        <span class="d-inline-block" tabindex="0" data-bs-toggle="tooltip" title="This resource is an instance of {{tool.instance_of}}"><span class="badge text-primary border border-primary">{{tool.instance_of}}</span></span>
+                        {%- if tool.how_to_access %}
+                        <span class="d-inline-block" tabindex="0" data-bs-toggle="tooltip" title="{{tool.how_to_access}}"><span class="badge text-primary border border-primary">  <i class="fas fa-key"></i></span></span>
+                        {%- endif %}
+                    </div>
+                    {%- endif %}
+                </td>
                 {%- capture related_pages %}
                 {%- for section in tool.related_pages %}
                 {%- for tag in section[1] %}

--- a/_includes/toollist.html
+++ b/_includes/toollist.html
@@ -92,16 +92,19 @@
             {%- assign hide_ids = hide_ids | append: " " | append: tool_id %}
             <tr class="collapse multi-collapse" id="{{tool_id}}">
                 {% if tool.url %}
-                <td><a href="{{tool.url}}">{{tool.name}}</a><a href="{{country_page.url}}"><span class="flag-icon ms-2 flag-icon-{{country_page.country_code | downcase }}"></span></a></td>
+                <td><a href="{{tool.url}}">{{tool.name}}</a><a href="{{country_page.url}}" data-bs-toggle="tooltip" title="{{country_page.title}}"><span class="flag-icon ms-2 flag-icon-{{country_page.country_code | downcase }}"></span></a></td>
                 {%- else %}
                 <td>{{tool.name}}<a href="{{country_page.url}}"><span class="flag-icon ms-2 flag-icon-{{country_page.country_code | downcase }}"></span></a></td>
                 {%- endif %}
                 <td>{{tool.description}}
-                {% if tool.instance_of %}
-                <div class="d-block">
-                    <span class="badge text-primary border border-primary">{{tool.instance_of}}</span>
-                </div>
-                {%- endif %}
+                    {%- if tool.instance_of or tool.how_to_access %}
+                    <div class="d-block">
+                        <span class="d-inline-block" tabindex="0" data-bs-toggle="tooltip" title="This resource is an instance of {{tool.instance_of}}"><span class="badge text-primary border border-primary">{{tool.instance_of}}</span></span>
+                        {%- if tool.how_to_access %}
+                        <span class="d-inline-block" tabindex="0" data-bs-toggle="tooltip" title="{{tool.how_to_access}}"><span class="badge text-primary border border-primary">  <i class="fas fa-key"></i></span></span>
+                        {%- endif %}
+                    </div>
+                    {%- endif %}
                 </td>
                 {%- capture related_pages %}
                 {%- for section in tool.related_pages %}


### PR DESCRIPTION
As a temporary solution, util we have a better one, I would add the `how_to_access` information from a national tool as a tooltip on a key icon to the description.

![Screenshot from 2021-12-16 14-14-03](https://user-images.githubusercontent.com/44875756/146394291-205ea004-26d1-43c6-a039-9ffd0f9dd7c5.png)

\+ instance of is also displayed on the national resource page now
\+ linking to country page in the navigation tiles of assemblies when clicked on a flag