### PR TITLE
Support for empty lists in metadata markdown

### DIFF
--- a/_includes/contributors-list.html
+++ b/_includes/contributors-list.html
@@ -1,8 +1,8 @@
-{%- if page.contributors %}
+{%- if page.contributors and page.contributors.size != 0 %}
 <span class="d-block h2-like fs-2 text-dark">Contributors</span>
 <div class="p-4 bg-light rounded mt-4">
     {%- assign contributors = site.data.CONTRIBUTORS -%}
-    {%- assign page_contributors = page.contributors |sort -%}
+    {%- assign page_contributors = page.contributors -%}
     {%- for contributor in page_contributors | sort %}
     {%- assign id = contributors[contributor].git | default: 'no_github' %}
     {%- capture html_code %}

--- a/_includes/further-reading.html
+++ b/_includes/further-reading.html
@@ -1,4 +1,9 @@
-{%- if page.related_pages or page.training or page.faircookbook or page.fairsharing %}
+{%- for section in page.related_pages %}
+{%- unless section[1] == blank  %}
+{%- assign actual_related = 1 %}
+{%- endunless %}
+{%- endfor %}
+{%- if actual_related != blank or page.faircookbook or page.fairsharing %}
 <!-- More information -->
 <h2>More information</h2>
 

--- a/_includes/further-reading.html
+++ b/_includes/further-reading.html
@@ -1,5 +1,5 @@
 {%- for section in page.related_pages %}
-{%- unless section[1] == blank  %}
+{%- unless section[1].size == 0  %}
 {%- assign actual_related = 1 %}
 {%- endunless %}
 {%- endfor %}

--- a/pages/national_resources/fi_resources.md
+++ b/pages/national_resources/fi_resources.md
@@ -1,8 +1,8 @@
 ---
 title: Finland
 country_code: FI
-contributors: 
-coordinators: 
+contributors: []
+coordinators: []
 resources:
   - name: Chipster
     description: Chipster is a user-friendly analysis software for high-throughput data such as RNA-seq and single cell RNA-seq. It contains analysis tools and a large reference genome collection.

--- a/pages/national_resources/fr_resources.md
+++ b/pages/national_resources/fr_resources.md
@@ -1,8 +1,8 @@
 ---
 title: France
 country_code: FR
-contributors: 
-coordinators: 
+contributors: []
+coordinators: []
 resources:
   - name: DMP OPIDoR
     description: Online questionnaire for the development of data management plans - repository of DMPs

--- a/pages/tool_assembly/ifb_assembly.md
+++ b/pages/tool_assembly/ifb_assembly.md
@@ -7,7 +7,7 @@ affiliations: ["ELIXIR Europe", "FR"]
 audience: [FR]
 related_pages: 
   your_tasks: [DMP, data organisation ,storage, data publication, data transfer, metadata, data analysis]
-  your_domain:
+  your_domain: []
 training:
   - name: Training in TeSS
     registry: TeSS

--- a/pages/tool_assembly/nels_assembly.md
+++ b/pages/tool_assembly/nels_assembly.md
@@ -7,7 +7,7 @@ affiliations: ["ELIXIR Europe", "NO"]
 audience: ["NO"]
 related_pages: 
   your_tasks: [DMP, data organisation ,storage, data publication, data transfer, metadata]
-  your_domain:
+  your_domain: []
 training:
   - name: Training in TeSS
     registry: TeSS

--- a/pages/your_domain/biomolecular_simulation_data.md
+++ b/pages/your_domain/biomolecular_simulation_data.md
@@ -2,6 +2,8 @@
 title: Biomolecular simulation data
 page_id: biomol sim
 related_pages: 
+  your_tasks: []
+  tool_assembly: []
 training:
   - name: Training in TeSS
     registry: TeSS

--- a/pages/your_domain/epitranscriptome_data.md
+++ b/pages/your_domain/epitranscriptome_data.md
@@ -3,6 +3,8 @@ title: Epitranscriptome data
 contributors: [Ernesto Picardi, Laura Portell Silva]
 page_id: epitrans
 related_pages: 
+  your_tasks: []
+  tool_assembly: []
 ---
 
 ## Introduction

--- a/pages/your_domain/intrinsically_disordered_proteins.md
+++ b/pages/your_domain/intrinsically_disordered_proteins.md
@@ -5,6 +5,7 @@ related_pages:
 page_id: IDP
 related_pages: 
   your_tasks: [metadata]
+  tool_assembly: []
 ---
 
 ## Introduction

--- a/pages/your_domain/microbial_biotechnology.md
+++ b/pages/your_domain/microbial_biotechnology.md
@@ -3,6 +3,8 @@ title: Microbial biotechnology
 contributors: [Anil Wipat, David Markham, Christian Atallah, Bradley Brown, Munazah Andrabi]
 page_id: micro biotech
 related_pages: 
+  your_tasks: []
+  tool_assembly: []
 ---
 
 ## Introduction

--- a/pages/your_domain/proteomics.md
+++ b/pages/your_domain/proteomics.md
@@ -4,6 +4,7 @@ contributors: [Michael Turewicz, Martin Eisenacher, Anika Frericks-Zipper, Ulrik
 page_id: proteomics
 related_pages: 
   your_tasks: [metadata]
+  tool_assembly: []
 training:
   - name: Training in TeSS
     registry: TeSS

--- a/pages/your_domain/structural_bioinformatics.md
+++ b/pages/your_domain/structural_bioinformatics.md
@@ -4,6 +4,8 @@ search_exclude: true
 contributors: [<!---REPLACE THIS with comma separated list of contributors--->]
 page_id: struct info
 related_pages: 
+  your_tasks: []
+  tool_assembly: []
 ---
 
 <!--- Domain pages should detail the particular data management challenges of the domain, typically by complementing and extending one or more existing Problem pages.

--- a/pages/your_domain/toxicology_data.md
+++ b/pages/your_domain/toxicology_data.md
@@ -4,6 +4,7 @@ contributors: [Manuel Pastor, Janet Piñero Gonzalez, Juan Manuel Ramírez-Angui
 page_id: toxicology data
 related_pages: 
   your_tasks: [data analysis]
+  tool_assembly: []
 ---
 
 ## Introduction

--- a/pages/your_tasks/data_publication.md
+++ b/pages/your_tasks/data_publication.md
@@ -7,6 +7,7 @@ faircookbook:
 - name: Depositing in Zenodo generic repository
   url: https://fairplus.github.io/the-fair-cookbook/content/recipes/findability/zenodo-deposition.html#
 related_pages: 
+    tool_assembly: []
 ---
 
 

--- a/pages/your_tasks/data_quality.md
+++ b/pages/your_tasks/data_quality.md
@@ -4,6 +4,7 @@ contributors: [Wei Gu, Pinar Alper, Kees van Bochove]
 description: ensure high quality research data.
 page_id: data quality
 related_pages: 
+    tool_assembly: []
 ---
 
 ## How do you ensure the quality of research data?

--- a/pages/your_tasks/data_transfer.md
+++ b/pages/your_tasks/data_transfer.md
@@ -9,6 +9,7 @@ faircookbook:
 - name: Downloading data with Aspera
   url: https://fairplus.github.io/the-fair-cookbook/content/recipes/accessibility/aspera.html 
 related_pages: 
+    tool_assembly: []
 training:
   - name: Training in TeSS
     registry: TeSS

--- a/pages/your_tasks/existing_data.md
+++ b/pages/your_tasks/existing_data.md
@@ -3,6 +3,7 @@ title: Existing data
 contributors: [Rob Hooft, Flora D'Anna, Pinar Alper, Yvonne Kallberg, Karel Berka, Marko Vidak, Olivier Collin, Ulrike Wittig]
 page_id: existing data
 related_pages: 
+    tool_assembly: []
 description: how to find and reuse existing data.
 ---
 

--- a/pages/your_tasks/identifiers.md
+++ b/pages/your_tasks/identifiers.md
@@ -4,6 +4,7 @@ contributors: [Markus Englund, Flavio Licciulli, Nick Juty, Olivier Collin, Ulri
 description: how to use identifiers for research data.
 page_id: identifiers
 related_pages: 
+    tool_assembly: []
 ---
 
 ## Which types of identifiers can you use during data collection?

--- a/pages/your_tasks/licensing.md
+++ b/pages/your_tasks/licensing.md
@@ -7,6 +7,7 @@ faircookbook:
 - name: Licensing
   url: https://fairplus.github.io/the-fair-cookbook/content/recipes/reusability/ATI-licensing.html#
 related_pages: 
+  tool_assembly: []
 ---
 
 ## Why should you assign a licence to your research data?

--- a/pages/your_tasks/machine_actionability.md
+++ b/pages/your_tasks/machine_actionability.md
@@ -6,6 +6,8 @@ page_id: machine actionability
 faircookbook:
 - name: Search engine optimization
   url: https://fairplus.github.io/the-fair-cookbook/content/recipes/findability/seo.html# 
+related_pages: 
+    tool_assembly: []
 ---
 
 ## What does machine-readable, machine-actionable or machine-interpretable mean for data and metadata in RDM?


### PR DESCRIPTION
This PR will add the possibility to add:

```yaml
contributors: []
coordinators: []
related_pages: 
  your_tasks: []
  tool_assembly: []
```
Without these section appearing on the website. This makes it easier to keep the structure from the template and to fill it in later
