### PR TITLE
Changing the menu links for 'Your role'

### DIFF
--- a/_data/sidebars/main.yml
+++ b/_data/sidebars/main.yml
@@ -8,11 +8,11 @@ subitems:
     subitems:
       - title: Researcher
         url: /researcher.html
-      - title: Data steward policy
+      - title: "Data Steward: policy"
         url: /data_steward_policy.html
-      - title: Data steward research
+      - title: "Data Steward: research"
         url: /data_steward_research.html
-      - title: Data steward infrastructure
+      - title: "Data Steward: infrastructure"
         url: /data_steward_infrastructure.html
   - title: Your domain
     description: Learn about the data management problems that affect your domain or research community, and the solutions adopted to address them.

--- a/pages/your_role/data_steward_infrastructure.md
+++ b/pages/your_role/data_steward_infrastructure.md
@@ -1,5 +1,5 @@
 ---
-title: Data steward infrastructure
+title: "Data Steward: infrastructure"
 contributors: [Mijke Jetten, Federico Bianchini, Gregoire Rossier, Erik Hjerde, Siiri Fuchs, Minna Ahokas, Priit Adler, Alexander Botzki, Robert Andrews, Celia van Gelder, Daniel Wibberg, Graham Hughes, Marko Vidak, Pedro Fernandes, Pinar Alper, Victoria Dominguez D. Angel, Wolmar Nyberg Åkerström, Alexia Cardona]
 page_id: IT support
 related_pages: 

--- a/pages/your_role/data_steward_policy.md
+++ b/pages/your_role/data_steward_policy.md
@@ -1,5 +1,5 @@
 ---
-title: Data steward policy
+title: "Data Steward: policy"
 contributors: [Mijke Jetten, Federico Bianchini, Gregoire Rossier, Erik Hjerde, Siiri Fuchs, Minna Ahokas, Priit Adler, Alexander Botzki, Robert Andrews, Celia van Gelder, Daniel Wibberg, Graham Hughes, Marko Vidak, Pedro Fernandes, Pinar Alper, Victoria Dominguez D. Angel, Wolmar Nyberg Åkerström, Alexia Cardona]
 page_id: policy officer
 related_pages: 

--- a/pages/your_role/data_steward_research.md
+++ b/pages/your_role/data_steward_research.md
@@ -1,5 +1,5 @@
 ---
-title: Data steward research
+title: "Data Steward: research"
 contributors: [Mijke Jetten, Federico Bianchini, Gregoire Rossier, Erik Hjerde, Siiri Fuchs, Minna Ahokas, Priit Adler, Alexander Botzki, Robert Andrews, Celia van Gelder, Daniel Wibberg, Graham Hughes, Marko Vidak, Pedro Fernandes, Pinar Alper, Victoria Dominguez D. Angel, Wolmar Nyberg Åkerström, Alexia Cardona]
 page_id: data manager
 related_pages: 


### PR DESCRIPTION
This is included in #680. The side menu links have been changed from the format "Data steward policy" to "Data Steward: policy". The page titles have also been changed to reflect the new format.