### PR TITLE
Read next section

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -7,7 +7,7 @@ topnav_title:
 description: "Find the answers to your Research Data Management questions in Life Sciences."
 # Metadata description of the website
 
-remote_theme: ELIXIR-Belgium/jekyll-bootstrap-theme@read-next
+remote_theme: ELIXIR-Belgium/jekyll-bootstrap-theme@1.2.0
 
 gtag: G-RXQ55EFTTH
 # Google analytics tag

--- a/_config.yml
+++ b/_config.yml
@@ -7,7 +7,7 @@ topnav_title:
 description: "Find the answers to your Research Data Management questions in Life Sciences."
 # Metadata description of the website
 
-remote_theme: ELIXIR-Belgium/jekyll-bootstrap-theme@1.2.0
+remote_theme: ELIXIR-Belgium/jekyll-bootstrap-theme@1.2.1
 
 gtag: G-RXQ55EFTTH
 # Google analytics tag

--- a/_config.yml
+++ b/_config.yml
@@ -7,7 +7,7 @@ topnav_title:
 description: "Find the answers to your Research Data Management questions in Life Sciences."
 # Metadata description of the website
 
-remote_theme: ELIXIR-Belgium/jekyll-bootstrap-theme@1.1.2
+remote_theme: ELIXIR-Belgium/jekyll-bootstrap-theme@read-next
 
 gtag: G-RXQ55EFTTH
 # Google analytics tag


### PR DESCRIPTION
As follow up to the close #697 issue.  During our first UX session and also when Dom was going over our website, people miss quickly that it is really recommended to read the related pages we have selected for them (especially on the data life cycle pages) .

This PR puts more emphasis on this and makes a separate section called `What to read next?` to the pages. This can off cource be changed.

![Screenshot from 2022-02-12 09-53-58](https://user-images.githubusercontent.com/44875756/153704745-206aef86-019f-4b1f-8aff-c3aebc5889fe.png)

