### PR TITLE
Added contributor details for struct bioinfo

### DIFF
--- a/_data/CONTRIBUTORS.yaml
+++ b/_data/CONTRIBUTORS.yaml
@@ -307,3 +307,15 @@ Susanne Kunis:
 Eva Alloza:
     email: eva.alloza@bsc.es
     git: EvaAlloza
+Gerardo Tauriello:
+    orcid: 0000-0002-5921-7007
+    git: gtauriello
+    affiliation: SIB / University of Basel
+Mihaly Varadi:
+    orcid: 0000-0002-3687-0839
+    git: mvaradi
+    affiliation: EMBL-EBI
+Jiří Černý:
+    orcid: 0000-0002-1969-9304
+    email: jiri.cerny@ibt.cas.cz
+    affiliation: Institute of Biotechnology


### PR DESCRIPTION
Following up from #831 : added some metadata for the contributors to the structural bioinformatics page.