### PR TITLE
Improvements in the all tool and resources mechanics

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -7,7 +7,7 @@ topnav_title:
 description: "Find the answers to your Research Data Management questions in Life Sciences."
 # Metadata description of the website
 
-remote_theme: ELIXIR-Belgium/jekyll-bootstrap-theme@all-resources
+remote_theme: ELIXIR-Belgium/jekyll-bootstrap-theme@1.4.0
 
 gtag: G-RXQ55EFTTH
 # Google analytics tag

--- a/_config.yml
+++ b/_config.yml
@@ -7,7 +7,7 @@ topnav_title:
 description: "Find the answers to your Research Data Management questions in Life Sciences."
 # Metadata description of the website
 
-remote_theme: ELIXIR-Belgium/jekyll-bootstrap-theme@1.2.2
+remote_theme: ELIXIR-Belgium/jekyll-bootstrap-theme@all-resources
 
 gtag: G-RXQ55EFTTH
 # Google analytics tag

--- a/_data/tool_and_resource_list.yml
+++ b/_data/tool_and_resource_list.yml
@@ -1,4 +1,3 @@
-Tools:
 - description: Network providing unified programmatic access to experimentally determined
     and predicted structure models
   link: https://3d-beacons.org

--- a/index.html
+++ b/index.html
@@ -270,7 +270,7 @@ layout: page
       {%- for country_page in country_pages %}
       {%- assign national_tools = national_tools | plus: country_page.resources.size %}
       {%- endfor %}
-      <span class="count-number text-primary">{{tools.Tools.size | plus: national_tools }}</span>
+      <span class="count-number text-primary">{{tools.size | plus: national_tools }}</span>
       <p><b>Tools & resources</b><br>
       Explained in the context of real world problems</p>
     </div>

--- a/pages/national_resources/ee_national_resources.md
+++ b/pages/national_resources/ee_national_resources.md
@@ -1,55 +1,67 @@
 ---
 
 title: Estonia
-search_exclude: true
 country_code: EE
-contributors: [<!---REPLACE THIS with comma separated list of contributors--->]
-coordinators: [<!---REPLACE THIS with the name of data management coordinators of your ELIXIR node--->]
-
-related_pages: 
-  tool_assembly: [<!---REPLACE THIS with the page ID of the tool_assembly pages that you want to list here as related pages--->]
-
-training:
-  - name: Training in TeSS
-    registry: TeSS
-    registry_url: https://tess.elixir-europe.org
-    url: <!--- https://tess.elixir-europe.org/materials?node=NODENAME --->
-  - name: ELIXIR NODENAME community in Zenodo
-    registry: Zenodo
-    registry_url: https://zenodo.org
-    url: <!--- https://zenodo.org/communities/elixir NODENAME --->
-  - name: ELIXIR NODENAME YouTube
-    url: <!--- URL of the channel --->
-  - name: <!---REPLACE THIS with the name of your training in registry or platform--->
-    registry: <!---REPLACE THIS with the name of the registry--->
-    registry_url: <!---REPLACE THIS with the url of the registry--->
-    url: <!---REPLACE THIS with the url of your training registry or platform--->
+contributors: [Heleri Inno]
+coordinators: [Heleri Inno]
 
 resources:
-  - name: <!---REPLACE THIS with the national resources about RDM in life sciences such as local instances of tools, guidelines or regulations--->
-    description:
-    how_to_access: <!--- free text to explain if credentials, login, specific affiliations etc are needed to access the resource or tool--->
+  - name: Galaxy Estonia
+    description: This is the Estonian instance of  Galaxy, which is an open source, web-based platform for data intensive biomedical research.
+    how_to_access:
+    instance_of: Galaxy
     related_pages:
-      tool_assembly: [<!---REPLACE THIS with the page ID of the tool_assembly pages that you want to list here as related pages--->]
-      your_domain: [<!---REPLACE THIS with the page ID of the domain pages that you want to list here as related pages--->]
-      your_role: [<!---REPLACE THIS with the page ID of the your_role pages that you want to list here as related pages--->]
-      your_tasks: [<!---REPLACE THIS with the page ID of the your_tasks pages that you want to list here as related pages--->]
-    url:
+      tool_assembly:
+      your_domain:
+      your_role: [researcher]
+      your_tasks: [data analysis]
+    url: https://galaxy.hpc.ut.ee/
+
+  - name: REDCap Estonia
+    description: This is the Estonian instance of REDCap, which is a secure web platform for building and managing online databases and surveys. 
+    how_to_access:
+    instance_of: REDCap
+    related_pages:
+      tool_assembly:
+      your_domain:
+      your_role: [data manager]
+      your_tasks: [data quality]
+    url: https://redcap.ut.ee/
 ---
-<!---All the resources added above will appear on the table at the bottom of the page--->
 
-<!---Following information for the page text--->
-<!---Use this template as guidance, all fields are optional. Feel free to modify any section if you think it is necessary--->
-<!---If the information is already in another resource, please include the link instead of duplicating information--->
-<!---Please focus on resources that are relevant for the whole country for life sciences--->
+## Introduction
 
-## Introduction 
-<!---General RDM considerations for your country, how to deal with RDM on a national level--->
+This page provides an overview of the data management resources and initiatives in Estonia. All these references are meant for Estonian researchers and their collaborators. 
+
+The Estonian government has released an [“Estonian Research and Development, Innovation and Entrepreneurship Strategy 2021-2035”](https://www.hm.ee/sites/default/files/taie_arengukava_kinnitatud_15.07.2021_211109a_en_final.pdf). 
 
 ## Funders
 
-## Regulations
-<!--- Ethical and legal regulations in the country, committees etc --->
+* [Estonian Research Council](https://www.etag.ee/en/)
+* [Republic of Estonia Education and Youth Board](https://harno.ee/en)
 
-## Domain-specific infrastructures or resources 
-<!--- e.g. human data, covid-19. Please, only add domain-specific resources that you think don't fit in the table at the bottom--->
+## Relevant initiatives
+<!--- Ethical and legal regulations in the country, committees etc; we mostly don't have these, we will add different organisations dealing with data management in Estonia --->
+
+### Organisations
+* [Estonian Research Council](https://www.etag.ee/en/activities/horizontal-topics/open-science/) open science policies, surveys and documentation. 
+* ELIXIR Estonia [Data Management page](https://elixir.ut.ee/datamanagement): general information about data management and specific recommendations and references on how to manage your scientific data in Estonia. 
+* [Open Knowledge Estonia dataclub](https://okee.ee/andmeklubi/): monthly seminars on different topics of data management. 
+
+### Libraries
+* [University of Tartu Library](https://utlib.ut.ee/en/open-science) open science page. The main focus is on Open Science and Open Access and how to write a Data Management Plan
+* [Library of Estonian University of Life Sciences](https://library.emu.ee/en/research/open-science/) open science page.
+* [Tallinn University of Technology](https://taltech.ee/en/library/open-science) open science page.
+
+### Other initiatives
+* [Open Science in Estonia](https://www.avatudteadus.ee/en/home/): the official Open Science branding of Estonia, developed by the University of Tartu Library. Contains information about community, initiatives, infrastructure and services.
+
+## Domain-specific infrastructures or resources
+
+* [ELIXIR Estonia](https://elixir.ut.ee/services) list of services that are provided. 
+* [Estonian Research Information System](https://www.etis.ee/Portal/News/Index/?IsLandingPage=true&lang=ENG#) contains information about the researchers and the projects. 
+* [DataDOI](https://datadoi.ee/) is an Estonian National repository. 
+* [PlutoF](https://plutof.ut.ee/) is a data management and publishing platform. 
+* [The High Performance Computing Center](https://hpc.ut.ee/en/home/)
+* [Estonian Scientific Computing Infrastructure ETAIS](https://etais.ee/)
+* [Covid-19 Data Portal](https://covid19dataportal.ee/en/about/)

--- a/var/conversions.py
+++ b/var/conversions.py
@@ -121,7 +121,6 @@ def remove_prefix(s, prefix):
 table_path = "_data/main_tool_and_resource_list.csv"
 output_path = "_data/tool_and_resource_list.yml"
 related_pages_path = "_data/page_ids.yml"
-main_dict_key = "Tools"
 rootdir = 'pages/'
 allowed_registries = ['biotools', 'fairsharing', 'tess', 'fairsharing-coll']
 
@@ -150,7 +149,7 @@ print(f"----> Allowed related_pages: {', '.join(pages_metadata.keys())}.")
 
 print(f"----> Converting table {table_path} to {output_path} started.")
 args = process_args()
-main_dict = {main_dict_key: []}
+main_list = []
 if args.reg:
     fairsharing_token = get_fairsharing_token(args.username, args.password)
 with open(table_path, 'r') as read_obj:
@@ -207,10 +206,10 @@ with open(table_path, 'r') as read_obj:
                     output = unicodedata.normalize("NFKD", cell).strip()
                 if output:
                     tool[header[col_index]] = output
-            main_dict[main_dict_key].append(tool)
+            main_list.append(tool)
             print(f"{row_index}. {tool['name']} is parsed.")
 
 with open(output_path, 'w') as yaml_file:
-    documents = yaml.dump(main_dict, yaml_file)
+    documents = yaml.dump(main_list, yaml_file)
 
 print("----> YAML is dumped successfully")


### PR DESCRIPTION
- Bug fixed: national resource did not show up in all tools and resources if it did not have a related page
- country pages only one time assigned
- No title `<h2>Relevant tools and resources</h2>` when not filtering on a tag
- No national resources button on the all tools and resources page, all are listed. This was not correct anyway when using the search function in the table