### PR TITLE
link MA to role pages

### DIFF
--- a/pages/your_role/data_steward_infrastructure.md
+++ b/pages/your_role/data_steward_infrastructure.md
@@ -3,7 +3,7 @@ title: "Data Steward: infrastructure"
 contributors: [Mijke Jetten, Federico Bianchini, Gregoire Rossier, Erik Hjerde, Siiri Fuchs, Minna Ahokas, Priit Adler, Alexander Botzki, Robert Andrews, Celia van Gelder, Daniel Wibberg, Graham Hughes, Marko Vidak, Pedro Fernandes, Pinar Alper, Victoria Dominguez D. Angel, Wolmar Nyberg Åkerström, Alexia Cardona]
 page_id: IT support
 related_pages: 
-  your_tasks: [data analysis, data protection, transfer, identifiers, storage, data organisation]
+  your_tasks: [data analysis, data protection, transfer, identifiers, storage, data organisation, machine actionability]
 training:
   - name: TeSS - ELIXIR’s training portal
     registry: TeSS

--- a/pages/your_role/data_steward_research.md
+++ b/pages/your_role/data_steward_research.md
@@ -3,7 +3,7 @@ title: "Data Steward: research"
 contributors: [Mijke Jetten, Federico Bianchini, Gregoire Rossier, Erik Hjerde, Siiri Fuchs, Minna Ahokas, Priit Adler, Alexander Botzki, Robert Andrews, Celia van Gelder, Daniel Wibberg, Graham Hughes, Marko Vidak, Pedro Fernandes, Pinar Alper, Victoria Dominguez D. Angel, Wolmar Nyberg Åkerström, Alexia Cardona]
 page_id: data manager
 related_pages: 
-  your_tasks: [compliance, DMP, data organisation, licensing, metadata, data protection, data publication, data quality, transfer, identifiers]
+  your_tasks: [compliance, DMP, data organisation, licensing, metadata, data protection, data publication, data quality, transfer, identifiers, machine actionability]
 training:
   - name: TeSS - ELIXIR’s training portal
     registry: TeSS


### PR DESCRIPTION
Add machine actionability page (task) to role pages data steward infrastructure and researcher.