### PR TITLE
Sidebar title line

### DIFF
--- a/_sass/_custom_classes.scss
+++ b/_sass/_custom_classes.scss
@@ -35,6 +35,8 @@ li ul .sidebar_rdm_sub {
     border-bottom: 0.2rem solid $primary;
     font-weight: bold;
     padding-bottom: $input-btn-padding-y - 0.2rem;
+    border-width: 0 0 0.2rem;
+    border-radius: 0;
 }
 
 #side-nav > ul {


### PR DESCRIPTION
Currently the sidebar title is living in a rounded box which makes the line look like this:
![Screenshot from 2022-03-15 12-05-54](https://user-images.githubusercontent.com/44875756/158365037-4ad13838-0291-4503-abfa-9fa8a700612a.png)
with the hover state like this:

![Screenshot from 2022-03-15 12-06-21](https://user-images.githubusercontent.com/44875756/158365067-bc4550ad-6e3e-43a8-a57b-12b5735202b8.png)

@martin-nc gave a suggestion to make this straight:

![Screenshot from 2022-03-15 12-06-51](https://user-images.githubusercontent.com/44875756/158365134-12509144-675b-4bfa-8877-2afd33664e41.png)

which makes the hover state look like this

![Screenshot from 2022-03-15 12-06-57](https://user-images.githubusercontent.com/44875756/158365220-51d4ba62-ed6e-47f0-9715-65e93523dd75.png)

