### PR TITLE
Adding presentations

### DIFF
--- a/pages/about/media_kit.md
+++ b/pages/about/media_kit.md
@@ -2,7 +2,7 @@
 title: Media kit
 ---
 
-Here you can find materials that are out of the box avaibale for use outside RDMkit. The logo's and images listed here are licensed under a Creative Commons Attribution 4.0 International License, just like the rest of the content on RDMkit. This means that you can use them, as long as you give attribution to RDMkit. If possible, make use of the svg image since this will preserve the image quality better.
+Here you can find materials that are out of the box available for use outside RDMkit. The logo's and images listed here are licensed under a Creative Commons Attribution 4.0 International License, just like the rest of the content on RDMkit. This means that you can use them, as long as you give attribution to RDMkit. If possible, make use of the svg image since this will preserve the image quality better.
 
 ## RDMkit logo
 

--- a/pages/about/media_kit.md
+++ b/pages/about/media_kit.md
@@ -66,6 +66,13 @@ For use in presentations, tutorials and all other RDMkit related activities the 
     [<a href="{{ 'images/data_life_cycle_3.png' | relative_url }}">png</a>]
 </p>
 
+## Presentations
+
+#### RDMkit in 1 and 3 slides
+
+<iframe  class="scale" src="https://docs.google.com/presentation/d/e/2PACX-1vQN8VjdCv96Jwdd1H8r-bxhVPk1wgI-FBTfuHiHX1_7R9HCl30W6GDPXMSm_bQkwz99vK0KGDYY3Na2/embed?start=false&loop=false&delayms=3000" frameborder="0" width="960" height="569" allowfullscreen="true" mozallowfullscreen="true" webkitallowfullscreen="true"></iframe>
+
+
 ## Promotion gif
 
 <p>

--- a/pages/about/media_kit.md
+++ b/pages/about/media_kit.md
@@ -2,7 +2,7 @@
 title: Media kit
 ---
 
-The logo's and images listed here are licensed under a Creative Commons Attribution 4.0 International License, just like the rest of the content on RDMkit. This means that you can use them, as long as you give attribution to RDMkit. 
+Here you can find materials that are out of the box avaibale for use outside RDMkit. The logo's and images listed here are licensed under a Creative Commons Attribution 4.0 International License, just like the rest of the content on RDMkit. This means that you can use them, as long as you give attribution to RDMkit. If possible, make use of the svg image since this will preserve the image quality better.
 
 ## RDMkit logo
 

--- a/pages/about/outreach.md
+++ b/pages/about/outreach.md
@@ -2,6 +2,7 @@
 title: Outreach
 ---
 
+We are since the beginning actively spreading the word about RDMkit. On this page we keep track where we gave a presentation about RDMkit and the links towards those presentations if possible.
 
 ## Presentations
 

--- a/pages/about/outreach.md
+++ b/pages/about/outreach.md
@@ -51,6 +51,12 @@ NEURON organized an open virtual meeting “European Biomedical Research Infrast
 - [Youtube video](https://www.youtube.com/watch?v=qiKtDw15GmU)
 - [Presentation](https://www.neuron-eranet.eu/wp-content/uploads/RDMkit-DSW-ERANet-Neuron.pdf)
 
+### RDMkit on the NIH Data Sharing and Reuse Seminar 2022
+
+**2022-03-11**
+
+<iframe class="scale" src="https://docs.google.com/presentation/d/e/2PACX-1vSkyhr1ifD_eJ-Dq7sgrmOjE-bj1ZNfiZFgKzInmjoM8N5m8y5HIbVpP9A4SxucFA/embed?start=false&loop=false&delayms=3000" frameborder="0" width="1280" height="749" allowfullscreen="true" mozallowfullscreen="true" webkitallowfullscreen="true"></iframe>
+
 ## Videos
 
 ### ELIXIR Webinar: Research Data Management Kit (RDMKit)


### PR DESCRIPTION
This adds the 1 and 3 slides about RDMkit + the presentation given at NIH Data Sharing and Reuse Seminar 2022.

I have a general question for @elixir-europe/rdmkit-editors , I am not sure about the difference between the page Outreach and the page Media kit. Mediakit seems to contain stuff that can be reused right away, while outreach contains more info about what we have done for PR in general. Is this the truth + is this clear for the user?
