### PR TITLE
Update used KM for DSW integration

### DIFF
--- a/var/dsw_integration.py
+++ b/var/dsw_integration.py
@@ -13,7 +13,8 @@ import yaml
 rootdir = 'pages/'
 DSWQuestion = collections.namedtuple('DSWQuestion', 'uuid, text')
 RDMKIT_PREFIX = 'https://rdmkit.elixir-europe.org'
-
+DSW_API_URL = 'https://api-converge.ds-wizard.org'
+DSW_KM_ID = 'dsw:root:latest'
 
 # --------- Functions ---------
 
@@ -64,8 +65,8 @@ def fetch_rdmkit_dsw_links(endpoint: str, package: str) -> Dict[str, List[DSWQue
 
 # --------- Parsing DSW json ---------
 parent_ids = fetch_rdmkit_dsw_links(
-    endpoint='https://api-converge.ds-wizard.org',
-    package='dsw:root-rdmkit:latest',
+    endpoint=DSW_API_URL,
+    package=DSW_KM_ID,
 )
 
 


### PR DESCRIPTION
After releasing `dsw:root:2.4.0` (that includes a set of changes made during the DSW-RDMkit hackathons as well as changes for Horizon Europe DMPs), we decided with @rwwh to keep updating directly `dsw:root` KM instead of having the *Common DSW Knowledge Model (RDMkit WIP)* (`dsw:root-rdmkit`).