### PR TITLE
Adding support for more training registries

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -4,7 +4,7 @@ title: RDMkit
 description: "Find the answers to your Research Data Management questions in Life Sciences."
 # Metadata description of the website
 
-remote_theme: ELIXIR-Belgium/elixir-toolkit-theme@zenodo
+remote_theme: ELIXIR-Belgium/elixir-toolkit-theme@1.15.0
 
 sass:
   style: compressed

--- a/_config.yml
+++ b/_config.yml
@@ -4,7 +4,7 @@ title: RDMkit
 description: "Find the answers to your Research Data Management questions in Life Sciences."
 # Metadata description of the website
 
-remote_theme: ELIXIR-Belgium/elixir-toolkit-theme@1.13.0
+remote_theme: ELIXIR-Belgium/elixir-toolkit-theme@zenodo
 
 sass:
   style: compressed

--- a/pages/contribute/editorial_board_guide.md
+++ b/pages/contribute/editorial_board_guide.md
@@ -72,7 +72,7 @@ Optional metadata/frontmatter:
     tool_assembly: [page_id1, page_id2]
     ``` 
 
-* `training`: List here training material relevant for the page. We recommend to add your training material in TeSS. However, you can also list here training material that is not yet present in TeSS. Each training item will be automatically added as an entry to the table in the [All training resources page](all_training_resources).
+* `training`: List here training material relevant for the page. We recommend to add your training material in TeSS. However, you can also list here training material that is not yet present in TeSS. Each training item will be automatically added as an entry to the table in the [All training resources page](all_training_resources). If the registry is specified, please use one of the following: TeSS, Youtube, Zenodo or Carpentries.
 
   ```yml
   training:
@@ -84,12 +84,12 @@ Optional metadata/frontmatter:
       registry: TeSS
       url: https://tess.elixir-europe.org/search?q=data%20analysis
   ```
-
 * `faircookbook`: Here all relevant FAIR Cookbook recipes are listed. This is automaticity updated based on the [`faircookbook_rdmkit_mapping.yml`](https://github.com/elixir-europe/rdmkit/tree/master/_data/faircookbook_rdmkit_mapping.yml) mapping file. If you want to make a new link, please make a pull request against this file. Every week the changes of this mapping file are used to update the frontmatter of the corresponding markdown files.
+
 
 * `dsw`: Here all relevant Data Stewardship Wizard questions in the RDMkit knowledge model are listed. This is automaticity updated and can not be altered by humans! If you want to add a link you have to add the link towards the RDMkit page the the knowledge model on DSW.
 
-* `datatable`: Use this attribute to activate pagination, sorting  and searching in tables.
+* `datatable`: use this attribute to activate the pagination + sorting + searching in tables
 
 ### Markdown file naming
 

--- a/pages/contribute/editorial_board_guide.md
+++ b/pages/contribute/editorial_board_guide.md
@@ -78,12 +78,10 @@ Optional metadata/frontmatter:
   training:
     - name: Training in TeSS
       registry: TeSS
-      registry_url: https://tess.elixir-europe.org
       url: https://tess.elixir-europe.org/search?q=data%20analysis
 
     - name: Training in TeSS
       registry: TeSS
-      registry_url: https://tess.elixir-europe.org
       url: https://tess.elixir-europe.org/search?q=data%20analysis
   ```
 

--- a/pages/contribute/markdown_cheat_sheet.md
+++ b/pages/contribute/markdown_cheat_sheet.md
@@ -74,12 +74,10 @@ faircookbook:
   training:
     - name: Training in TeSS
       registry: TeSS
-      registry_url: https://tess.elixir-europe.org
       url: https://tess.elixir-europe.org/search?q=data%20analysis
 
     - name: Training in TeSS
       registry: TeSS
-      registry_url: https://tess.elixir-europe.org
       url: https://tess.elixir-europe.org/search?q=data%20analysis
   ```
 * `faircookbook`: Here all relevant FAIR Cookbook recipes are listed. This is automaticity updated based on the [`faircookbook_rdmkit_mapping.yml`](https://github.com/elixir-europe/rdmkit/tree/master/_data/faircookbook_rdmkit_mapping.yml) mapping file. If you want to make a new link, please make a pull request against this file. Every week the changes of this mapping file are used to update the frontmatter of the corresponding markdown files.
@@ -406,12 +404,10 @@ You can list training material by using the metadata fields as in the example be
 training:
    - name: Training in TeSS
      registry: TeSS
-     registry_url: https://tess.elixir-europe.org
      url: https://tess.elixir-europe.org/search?q=data%20analysis
 
    - name: Training in TeSS
      registry: TeSS
-     registry_url: https://tess.elixir-europe.org
      url: https://tess.elixir-europe.org/search?q=data%20analysis
 ```
 

--- a/pages/contribute/markdown_cheat_sheet.md
+++ b/pages/contribute/markdown_cheat_sheet.md
@@ -68,7 +68,7 @@ faircookbook:
     tool_assembly: [page_id1, page_id2]
   ``` 
 
-* `training`: List here training material relevant for the page. We recommend to add your training material in TeSS. However, you can also list here training material that is not yet present in TeSS. Each training item will be automatically added as an entry to the table in the [All training resources page](all_training_resources).
+* `training`: List here training material relevant for the page. We recommend to add your training material in TeSS. However, you can also list here training material that is not yet present in TeSS. Each training item will be automatically added as an entry to the table in the [All training resources page](all_training_resources). If the registry is specified, please use one of the following: TeSS, Youtube, Zenodo or Carpentries.
 
   ```yml
   training:

--- a/pages/contribute/markdown_cheat_sheet.md
+++ b/pages/contribute/markdown_cheat_sheet.md
@@ -224,22 +224,22 @@ The Font Awesome icons allow you to adjust their size by simply adding `fa-2x`, 
 Here's an example of how to scale up a camera icon:
 
 ```html
-<i class="fas fa-camera-retro"></i> normal size (1x)
-<i class="fas fa-camera-retro fa-lg"></i> fa-lg
-<i class="fas fa-camera-retro fa-2x"></i> fa-2x
-<i class="fas fa-camera-retro fa-3x"></i> fa-3x
-<i class="fas fa-camera-retro fa-4x"></i> fa-4x
-<i class="fas fa-camera-retro fa-5x"></i> fa-5x
+<i class="fa-solid fa-camera-retro"></i> normal size (1x)
+<i class="fa-solid fa-camera-retro fa-lg"></i> fa-lg
+<i class="fa-solid fa-camera-retro fa-2x"></i> fa-2x
+<i class="fa-solid fa-camera-retro fa-3x"></i> fa-3x
+<i class="fa-solid fa-camera-retro fa-4x"></i> fa-4x
+<i class="fa-solid fa-camera-retro fa-5x"></i> fa-5x
 ```
 
 Here's what they render to:
 
-<i class="fas fa-camera-retro"></i> 1x
-<i class="fas fa-camera-retro fa-lg"></i> fa-lg
-<i class="fas fa-camera-retro fa-2x"></i> fa-2x
-<i class="fas fa-camera-retro fa-3x"></i> fa-3x
-<i class="fas fa-camera-retro fa-4x"></i> fa-4x
-<i class="fas fa-camera-retro fa-5x"></i> fa-5x
+<i class="fa-solid fa-camera-retro"></i> 1x
+<i class="fa-solid fa-camera-retro fa-lg"></i> fa-lg
+<i class="fa-solid fa-camera-retro fa-2x"></i> fa-2x
+<i class="fa-solid fa-camera-retro fa-3x"></i> fa-3x
+<i class="fa-solid fa-camera-retro fa-4x"></i> fa-4x
+<i class="fa-solid fa-camera-retro fa-5x"></i> fa-5x
 
 ## Links
 

--- a/pages/data_life_cycle/TEMPLATE_rdm_cycle.md
+++ b/pages/data_life_cycle/TEMPLATE_rdm_cycle.md
@@ -8,7 +8,6 @@ related_pages:
 training:
   - name:
     registry:
-    registry_url:
     url:
 ---
 

--- a/pages/data_life_cycle/analysing.md
+++ b/pages/data_life_cycle/analysing.md
@@ -7,7 +7,6 @@ contributors: [Rob Hooft, Olivier Collin, Munazah Andrabi, Flora D'Anna]
 training:
   - name: Training in TeSS
     registry: TeSS
-    registry_url: https://tess.elixir-europe.org
     url: https://tess.elixir-europe.org/search?q=%22data+analysis%22#materials
 ---
 

--- a/pages/data_life_cycle/collecting.md
+++ b/pages/data_life_cycle/collecting.md
@@ -7,7 +7,6 @@ contributors: [Korbinian Bösl, Siiri Fuchs, Anastasia Chasapi, Ulrike Wittig]
 training:
   - name: Training in TeSS
     registry: TeSS
-    registry_url: https://tess.elixir-europe.org
     url: https://tess.elixir-europe.org/search?q=%22data+collection%22#materials
 dsw:
 - name: Specify a list of data sets you will be producing

--- a/pages/data_life_cycle/planning.md
+++ b/pages/data_life_cycle/planning.md
@@ -7,7 +7,6 @@ related_pages:
 training:
   - name: Training in TeSS
     registry: TeSS
-    registry_url: https://tess.elixir-europe.org
     url: https://tess.elixir-europe.org/search?q=%22data+management+planning%22#materials
 ---
 

--- a/pages/data_life_cycle/preserving.md
+++ b/pages/data_life_cycle/preserving.md
@@ -7,7 +7,6 @@ related_pages:
 training:
   - name: Training in TeSS
     registry: TeSS
-    registry_url: https://tess.elixir-europe.org
     url: https://tess.elixir-europe.org/search?q=%22data+preserve%22#materials
 dsw:
 - name: Specify a list of data sets you will be producing

--- a/pages/data_life_cycle/processing.md
+++ b/pages/data_life_cycle/processing.md
@@ -7,7 +7,6 @@ related_pages:
 training:
   - name: Training in TeSS
     registry: TeSS
-    registry_url: https://tess.elixir-europe.org
     url: https://tess.elixir-europe.org/search?q=%22data+process%22#materials
 dsw:
 - name: List the data formats you will be using for interpretation and describe their

--- a/pages/data_life_cycle/reusing.md
+++ b/pages/data_life_cycle/reusing.md
@@ -7,7 +7,6 @@ related_pages:
 training:
   - name: Training in TeSS
     registry: TeSS
-    registry_url: https://tess.elixir-europe.org
     url: https://tess.elixir-europe.org/search?q=%22data+reuse%22#materials
 dsw:
 - name: Is there any pre-existing data?

--- a/pages/data_life_cycle/sharing.md
+++ b/pages/data_life_cycle/sharing.md
@@ -7,7 +7,6 @@ related_pages:
 training:
   - name: Training in TeSS
     registry: TeSS
-    registry_url: https://tess.elixir-europe.org
     url: https://tess.elixir-europe.org/search?q=%22data+share%22#materials
 dsw:
 - name: When will the data set be published?

--- a/pages/national_resources/TEMPLATE_resources.md
+++ b/pages/national_resources/TEMPLATE_resources.md
@@ -12,7 +12,6 @@ related_pages:
 training:
   - name: Training in TeSS
     registry: TeSS
-    registry_url: https://tess.elixir-europe.org
     url: <!--- https://tess.elixir-europe.org/materials?node=NODENAME --->
   - name: ELIXIR NODENAME community in Zenodo
     registry: Zenodo

--- a/pages/national_resources/TEMPLATE_resources.md
+++ b/pages/national_resources/TEMPLATE_resources.md
@@ -15,13 +15,12 @@ training:
     url: <!--- https://tess.elixir-europe.org/materials?node=NODENAME --->
   - name: ELIXIR NODENAME community in Zenodo
     registry: Zenodo
-    registry_url: https://zenodo.org
     url: <!--- https://zenodo.org/communities/elixir NODENAME --->
   - name: ELIXIR NODENAME YouTube
+  - registry: Youtube
     url: <!--- URL of the channel --->
   - name: <!---REPLACE THIS with the name of your training in registry or platform--->
     registry: <!---REPLACE THIS with the name of the registry--->
-    registry_url: <!---REPLACE THIS with the url of the registry--->
     url: <!---REPLACE THIS with the url of your training registry or platform--->
 
 resources:

--- a/pages/national_resources/be_resources.md
+++ b/pages/national_resources/be_resources.md
@@ -11,7 +11,6 @@ related_pages:
 training:
   - name: Training in TeSS
     registry: TeSS
-    registry_url: https://tess.elixir-europe.org
     url: https://tess.elixir-europe.org/materials?node=Belgium
   - name: ELIXIR Belgium community in Zenodo
     registry: Zenodo

--- a/pages/national_resources/be_resources.md
+++ b/pages/national_resources/be_resources.md
@@ -14,9 +14,9 @@ training:
     url: https://tess.elixir-europe.org/materials?node=Belgium
   - name: ELIXIR Belgium community in Zenodo
     registry: Zenodo
-    registry_url: https://zenodo.org
     url: https://zenodo.org/communities/elixir-be/?page=1&size=20
   - name: ELIXIR Belgium YouTube
+    registry: Youtube
     url: https://www.youtube.com/channel/UC7XUideTn8tFCOC-lhT9-Aw
 
 resources:

--- a/pages/national_resources/de_resources.md
+++ b/pages/national_resources/de_resources.md
@@ -11,7 +11,6 @@ related_pages:
 training:
   - name: Training in TeSS
     registry: TeSS
-    registry_url: https://tess.elixir-europe.org
     url: https://tess.elixir-europe.org/materials?node=Germany
 
 

--- a/pages/national_resources/es_resources.md
+++ b/pages/national_resources/es_resources.md
@@ -7,7 +7,6 @@ coordinators: [Salvador Capella-Gutierrez]
 training:
   - name: Training in TeSS
     registry: TeSS
-    registry_url: https://tess.elixir-europe.org
     url: https://tess.elixir-europe.org/materials?node=Spain&scientific_topics=Data+management
     
 resources:

--- a/pages/national_resources/it_resources.md
+++ b/pages/national_resources/it_resources.md
@@ -15,13 +15,10 @@ training:
     url: <!--- https://tess.elixir-europe.org/materials?node=NODENAME --->
   - name: ELIXIR NODENAME community in Zenodo
     registry: Zenodo
-    registry_url: https://zenodo.org
     url: <!--- https://zenodo.org/communities/elixir NODENAME --->
   - name: ELIXIR NODENAME YouTube
     url: <!--- URL of the channel --->
   - name: <!---REPLACE THIS with the name of your training in registry or platform--->
-    registry: <!---REPLACE THIS with the name of the registry--->
-    registry_url: <!---REPLACE THIS with the url of the registry--->
     url: <!---REPLACE THIS with the url of your training registry or platform--->
 
 resources:

--- a/pages/national_resources/it_resources.md
+++ b/pages/national_resources/it_resources.md
@@ -17,6 +17,7 @@ training:
     registry: Zenodo
     url: <!--- https://zenodo.org/communities/elixir NODENAME --->
   - name: ELIXIR NODENAME YouTube
+    registry: Youtube
     url: <!--- URL of the channel --->
   - name: <!---REPLACE THIS with the name of your training in registry or platform--->
     url: <!---REPLACE THIS with the url of your training registry or platform--->

--- a/pages/national_resources/it_resources.md
+++ b/pages/national_resources/it_resources.md
@@ -12,7 +12,6 @@ related_pages:
 training:
   - name: Training in TeSS
     registry: TeSS
-    registry_url: https://tess.elixir-europe.org
     url: <!--- https://tess.elixir-europe.org/materials?node=NODENAME --->
   - name: ELIXIR NODENAME community in Zenodo
     registry: Zenodo

--- a/pages/national_resources/nl_resources.md
+++ b/pages/national_resources/nl_resources.md
@@ -12,7 +12,6 @@ related_pages:
 training:
   - name: Training in TeSS
     registry: TeSS
-    registry_url: https://tess.elixir-europe.org
     url: <!--- https://tess.elixir-europe.org/materials?node=NODENAME --->
   - name: ELIXIR NODENAME community in Zenodo
     registry: Zenodo

--- a/pages/national_resources/nl_resources.md
+++ b/pages/national_resources/nl_resources.md
@@ -15,13 +15,11 @@ training:
     url: <!--- https://tess.elixir-europe.org/materials?node=NODENAME --->
   - name: ELIXIR NODENAME community in Zenodo
     registry: Zenodo
-    registry_url: https://zenodo.org
     url: <!--- https://zenodo.org/communities/elixir NODENAME --->
   - name: ELIXIR NODENAME YouTube
     url: <!--- URL of the channel --->
   - name: <!---REPLACE THIS with the name of your training in registry or platform--->
     registry: <!---REPLACE THIS with the name of the registry--->
-    registry_url: <!---REPLACE THIS with the url of the registry--->
     url: <!---REPLACE THIS with the url of your training registry or platform--->
 
 resources:

--- a/pages/national_resources/nl_resources.md
+++ b/pages/national_resources/nl_resources.md
@@ -18,6 +18,7 @@ training:
     url: <!--- https://zenodo.org/communities/elixir NODENAME --->
   - name: ELIXIR NODENAME YouTube
     url: <!--- URL of the channel --->
+    registry: Youtube
   - name: <!---REPLACE THIS with the name of your training in registry or platform--->
     registry: <!---REPLACE THIS with the name of the registry--->
     url: <!---REPLACE THIS with the url of your training registry or platform--->

--- a/pages/national_resources/no_resources.md
+++ b/pages/national_resources/no_resources.md
@@ -14,9 +14,9 @@ training:
     url: https://tess.elixir-europe.org/events?include_expired=true&node=Norway
   - name: ELIXIR Norway community in Zenodo
     registry: Zenodo
-    registry_url: https://zenodo.org
     url: https://zenodo.org/communities/elixir-no/?page=1&size=20
 #  - name: ELIXIR Norway YouTube
+#    registry: Youtube
 #    url: https://www.youtube.com/channel/UCva4S9uWxXqyGnbSgxIbcwA
 
 

--- a/pages/national_resources/no_resources.md
+++ b/pages/national_resources/no_resources.md
@@ -11,7 +11,6 @@ related_pages:
 training:
   - name: Training in TeSS
     registry: TeSS
-    registry_url: https://tess.elixir-europe.org
     url: https://tess.elixir-europe.org/events?include_expired=true&node=Norway
   - name: ELIXIR Norway community in Zenodo
     registry: Zenodo

--- a/pages/national_resources/pt_resources.md
+++ b/pages/national_resources/pt_resources.md
@@ -11,7 +11,6 @@ related_pages:
 training:
   - name: Training in TeSS
     registry: TeSS
-    registry_url: https://tess.elixir-europe.org
     url: https://tess.elixir-europe.org/materials?node=Portugal
   - name: Ready for BioData.pt Data Management?
     registry: R4BDM

--- a/pages/national_resources/pt_resources.md
+++ b/pages/national_resources/pt_resources.md
@@ -13,8 +13,7 @@ training:
     registry: TeSS
     url: https://tess.elixir-europe.org/materials?node=Portugal
   - name: Ready for BioData.pt Data Management?
-    registry: R4BDM
-    registry_url: http://ready4biodatamanagement.biodata.pt/
+    registry: R4BDM http://ready4biodatamanagement.biodata.pt/
     url: http://ready4biodatamanagement.biodata.pt/
 
 resources:

--- a/pages/national_resources/se_resources.md
+++ b/pages/national_resources/se_resources.md
@@ -10,6 +10,7 @@ training:
     registry: TeSS
     url: https://tess.elixir-europe.org/events?include_expired=true&node=Sweden&scientific_topics=Data+management
   - name: SciLifeLab Data Management YouTube
+    registry: Youtube
     url: https://www.youtube.com/playlist?list=PL1nnHOyxN_WdqnzLqbmWJz_i0f2anT9cS
 
 resources:

--- a/pages/national_resources/se_resources.md
+++ b/pages/national_resources/se_resources.md
@@ -8,7 +8,6 @@ coordinators: [Niclas Jareborg, Yvonne Kallberg]
 training:
   - name: Training in TeSS
     registry: TeSS
-    registry_url: https://tess.elixir-europe.org
     url: https://tess.elixir-europe.org/events?include_expired=true&node=Sweden&scientific_topics=Data+management
   - name: SciLifeLab Data Management YouTube
     url: https://www.youtube.com/playlist?list=PL1nnHOyxN_WdqnzLqbmWJz_i0f2anT9cS

--- a/pages/tool_assembly/TEMPLATE_tool_assembly.md
+++ b/pages/tool_assembly/TEMPLATE_tool_assembly.md
@@ -11,7 +11,6 @@ related_pages:
 training:
   - name:
     registry:
-    registry_url:
     url:
 ---
 

--- a/pages/tool_assembly/csc_assembly.md
+++ b/pages/tool_assembly/csc_assembly.md
@@ -10,7 +10,6 @@ related_pages:
 training:
   - name: Training in TeSS
     registry: TeSS
-    registry_url: https://tess.elixir-europe.org
     url: https://tess.elixir-europe.org/search?q=csc
   - name: CSC - Bioscience webpages
     url: https://research.csc.fi/biosciences

--- a/pages/tool_assembly/csc_assembly.md
+++ b/pages/tool_assembly/csc_assembly.md
@@ -18,12 +18,14 @@ training:
   - name: CSC - Learning Materials for Bioscientists
     url: https://research.csc.fi/bioscience-learning-materials
   - name: CSC - Data management youtube channel
+    registry: Youtube
     url: https://www.youtube.com/watch?v=Ol7mniw687E&list=PLD5XtevzF3yEZw-8LadtaGVV8Um6CbMja
   - name: CSC - Research data management services for life science research (youtube video)
     url: https://youtu.be/lf9L7PYQrBE
   - name: Data analysis with Chipster - Course packages
     url: https://chipster.rahtiapp.fi/manual/courses.html
   - name: Tutorials and lecture playlists on different topics (youtube)
+    registry: Youtube
     url: https://www.youtube.com/channel/UCnL-Lx5gGlW01OkskZL7JEQ/playlists
 ---
 

--- a/pages/tool_assembly/ifb_assembly.md
+++ b/pages/tool_assembly/ifb_assembly.md
@@ -10,7 +10,6 @@ related_pages:
 training:
   - name: Training in TeSS
     registry: TeSS
-    registry_url: https://tess.elixir-europe.org
     url: https://tess.elixir-europe.org/search?q=IFB
   - name: Data management training at the IFB
     url: https://www.france-bioinformatique.fr/en/training/

--- a/pages/tool_assembly/marine_metagenomics_assembly.md
+++ b/pages/tool_assembly/marine_metagenomics_assembly.md
@@ -10,7 +10,6 @@ related_pages:
 training:
   - name: Training in TeSS
     registry: TeSS
-    registry_url: https://tess.elixir-europe.org
     url: https://tess.elixir-europe.org/search?q=marine+metagenomics
   - name: ELIXIR Norways training pages
     url: https://elixir.no/training/material

--- a/pages/tool_assembly/nels_assembly.md
+++ b/pages/tool_assembly/nels_assembly.md
@@ -10,7 +10,6 @@ related_pages:
 training:
   - name: Training in TeSS
     registry: TeSS
-    registry_url: https://tess.elixir-europe.org
     url: https://tess.elixir-europe.org/search?q=norway
 ---
 

--- a/pages/tool_assembly/omero_assembly.md
+++ b/pages/tool_assembly/omero_assembly.md
@@ -17,6 +17,7 @@ training:
   - name: Collection of workflow describing to how use the system, with links to scripts and notebooks
     url: https://omero-guides.readthedocs.io/en/latest/
   - name: YouTube channel with tutorials and presentations
+    registry: Youtube
     url: https://www.youtube.com/channel/UCyySB9ZzNi8aBGYqcxSrauQ
   - name: Imaging Forum - discussions about imaging related topics
     url: https://forum.image.sc/

--- a/pages/tool_assembly/xnat_pic_assembly.md
+++ b/pages/tool_assembly/xnat_pic_assembly.md
@@ -13,8 +13,10 @@ training:
   - name: Euro-Bioimaging website
     url: https://www.eurobioimaging.eu/news/towards-sharing-and-reusing-of-preclinical-image-data
   - name: Data Management - Biological and Preclinical Imaging Perspective
+    registry: Youtube
     url: https://www.youtube.com/QNiAGuFk53w
   - name: XNAT-PIC - expanding XNAT for image archiving and processing to Preclinical Imaging Centers
+    registry: Youtube
     url: ttps://www.youtube.com/cpEcfIJJqCo
 ---
 

--- a/pages/your_domain/TEMPLATE_your_domain.md
+++ b/pages/your_domain/TEMPLATE_your_domain.md
@@ -9,7 +9,6 @@ related_pages:
 training:
   - name:
     registry:
-    registry_url:
     url:
 ---
 

--- a/pages/your_domain/biomolecular_simulation_data.md
+++ b/pages/your_domain/biomolecular_simulation_data.md
@@ -8,7 +8,6 @@ related_pages:
 training:
   - name: Training in TeSS
     registry: TeSS
-    registry_url: https://tess.elixir-europe.org
     url: https://tess.elixir-europe.org/search?q=biomolecular%20simulation
   - name: BioExcel Knowledge Resource Center
     url: https://krc.bioexcel.eu/training

--- a/pages/your_domain/human_data.md
+++ b/pages/your_domain/human_data.md
@@ -8,7 +8,6 @@ related_pages:
 training:
   - name: Training in TeSS
     registry: TeSS
-    registry_url: https://tess.elixir-europe.org
     url: https://tess.elixir-europe.org/search?q=sensitive%20human%20data
   - name: A FAIR guide for data providers to maximise sharing of human genomic data
     url: https://journals.plos.org/ploscompbiol/article?id=10.1371/journal.pcbi.1005873

--- a/pages/your_domain/marine_metagenomics.md
+++ b/pages/your_domain/marine_metagenomics.md
@@ -9,7 +9,6 @@ related_pages:
 training:
   - name: Training in TeSS
     registry: TeSS
-    registry_url: https://tess.elixir-europe.org
     url: https://tess.elixir-europe.org/search?q=marine%20metagenomics
 ---
 

--- a/pages/your_domain/plant_sciences.md
+++ b/pages/your_domain/plant_sciences.md
@@ -9,7 +9,6 @@ related_pages:
 training:
   - name: Training in TeSS
     registry: TeSS
-    registry_url: https://tess.elixir-europe.org
     url: https://tess.elixir-europe.org/search?q=plant%20data%20management
 ---
 

--- a/pages/your_domain/proteomics.md
+++ b/pages/your_domain/proteomics.md
@@ -8,7 +8,6 @@ related_pages:
 training:
   - name: Training in TeSS
     registry: TeSS
-    registry_url: https://tess.elixir-europe.org
     url: https://tess.elixir-europe.org/search?q=proteomics
 ---
 

--- a/pages/your_domain/structural_bioinformatics.md
+++ b/pages/your_domain/structural_bioinformatics.md
@@ -9,7 +9,6 @@ related_pages:
 training:
   - name: Training in TeSS
     registry: TeSS
-    registry_url: https://tess.elixir-europe.org
     url: https://tess.elixir-europe.org/search?utf8=%E2%9C%93&q=Structural+Bioinformatics#workflows
 ---
 

--- a/pages/your_role/TEMPLATE_your_role.md
+++ b/pages/your_role/TEMPLATE_your_role.md
@@ -9,7 +9,6 @@ related_pages:
 training:
   - name:
     registry:
-    registry_url:
     url:
 ---
 

--- a/pages/your_role/data_steward_infrastructure.md
+++ b/pages/your_role/data_steward_infrastructure.md
@@ -11,27 +11,22 @@ training:
 
   - name: RDNL - Essentials for Data Support
     registry:
-    registry_url:
     url: https://datasupport.researchdata.nl/en/
 
   - name: Mantra - RDM training
     registry:
-    registry_url:
     url: https://mantra.edina.ac.uk/
 
   - name: GO FAIR resources
     registry:
-    registry_url:
     url: https://www.go-fair.org/resources/
 
   - name: Data Carpentry lessons
-    registry:
-    registry_url:
+    registry: Carpentries
     url: https://datacarpentry.org/lessons/
 
   - name: RDNL & DCC - Delivering RDM Services
     registry:
-    registry_url:
     url: https://www.futurelearn.com/courses/delivering-research-data-management-services
 
   - name: NPOS/ELIXIR data steward competency framework
@@ -40,7 +35,6 @@ training:
 
   - name: ELIXIR Data Management Network
     registry:
-    registry_url:
     url: https://elixir-europe.org/about-us/how-funded/eu-projects/converge/wp1/dm-coordinators
 ---
 

--- a/pages/your_role/data_steward_infrastructure.md
+++ b/pages/your_role/data_steward_infrastructure.md
@@ -6,7 +6,7 @@ related_pages:
   your_tasks: [data analysis, data protection, transfer, identifiers, storage, data organisation, machine actionability]
 training:
   - name: TeSS - ELIXIR’s training portal
-    registry: TeSS/
+    registry: TeSS
     url: https://tess.elixir-europe.org/search?q=%22IT%20support%22#materials
 
   - name: RDNL - Essentials for Data Support

--- a/pages/your_role/data_steward_infrastructure.md
+++ b/pages/your_role/data_steward_infrastructure.md
@@ -36,7 +36,6 @@ training:
 
   - name: NPOS/ELIXIR data steward competency framework
     registry: Zenodo
-    registry_url: https://zenodo.org
     url: https://zenodo.org/record/3490855#.YArTH-lKi7o
 
   - name: ELIXIR Data Management Network

--- a/pages/your_role/data_steward_infrastructure.md
+++ b/pages/your_role/data_steward_infrastructure.md
@@ -6,8 +6,7 @@ related_pages:
   your_tasks: [data analysis, data protection, transfer, identifiers, storage, data organisation, machine actionability]
 training:
   - name: TeSS - ELIXIR’s training portal
-    registry: TeSS
-    registry_url: https://tess.elixir-europe.org/
+    registry: TeSS/
     url: https://tess.elixir-europe.org/search?q=%22IT%20support%22#materials
 
   - name: RDNL - Essentials for Data Support

--- a/pages/your_role/data_steward_policy.md
+++ b/pages/your_role/data_steward_policy.md
@@ -6,7 +6,7 @@ related_pages:
   your_tasks: [compliance, licensing, DMP, data protection, sensitive]
 training:
   - name: TeSS - ELIXIR’s training portal
-    registry: TeSS/
+    registry: TeSS
     url: https://tess.elixir-europe.org/search?q=%22policy%20officer%22#materials
 
   - name: RDNL - Essentials for Data Support

--- a/pages/your_role/data_steward_policy.md
+++ b/pages/your_role/data_steward_policy.md
@@ -11,27 +11,22 @@ training:
 
   - name: RDNL - Essentials for Data Support
     registry:
-    registry_url:
     url: https://datasupport.researchdata.nl/en/
 
   - name: Mantra - RDM training
     registry:
-    registry_url:
     url: https://mantra.edina.ac.uk/
 
   - name: FAIR guiding principles
     registry:
-    registry_url:
     url: https://www.go-fair.org/fair-principles/
 
   - name: Data Carpentry lessons
-    registry:
-    registry_url:
+    registry: Carpentries
     url: https://datacarpentry.org/lessons/
 
   - name: RDNL & DCC - Delivering RDM Services
     registry:
-    registry_url:
     url: https://www.futurelearn.com/courses/delivering-research-data-management-services
 
   - name: NPOS/ELIXIR data steward competency framework
@@ -40,12 +35,10 @@ training:
 
   - name: ELIXIR Data Management Network
     registry:
-    registry_url:
     url: https://elixir-europe.org/about-us/how-funded/eu-projects/converge/wp1/dm-coordinators
 
   - name: Science Europe - Practical Guide to the International Alignment of RDM
     registry:
-    registry_url:
     url: https://www.scienceeurope.org/our-resources/practical-guide-to-the-international-alignment-of-research-data-management/
 ---
 

--- a/pages/your_role/data_steward_policy.md
+++ b/pages/your_role/data_steward_policy.md
@@ -36,7 +36,6 @@ training:
 
   - name: NPOS/ELIXIR data steward competency framework
     registry: Zenodo
-    registry_url: https://zenodo.org
     url: https://zenodo.org/record/3490855#.YArTH-lKi7o
 
   - name: ELIXIR Data Management Network

--- a/pages/your_role/data_steward_policy.md
+++ b/pages/your_role/data_steward_policy.md
@@ -6,8 +6,7 @@ related_pages:
   your_tasks: [compliance, licensing, DMP, data protection, sensitive]
 training:
   - name: TeSS - ELIXIR’s training portal
-    registry: TeSS
-    registry_url: https://tess.elixir-europe.org/
+    registry: TeSS/
     url: https://tess.elixir-europe.org/search?q=%22policy%20officer%22#materials
 
   - name: RDNL - Essentials for Data Support

--- a/pages/your_role/data_steward_research.md
+++ b/pages/your_role/data_steward_research.md
@@ -6,7 +6,7 @@ related_pages:
   your_tasks: [compliance, DMP, data organisation, licensing, metadata, data protection, data publication, data quality, transfer, identifiers, machine actionability]
 training:
   - name: TeSS - ELIXIR’s training portal
-    registry: TeSS/
+    registry: TeSS
     url: https://tess.elixir-europe.org/search?q=%22data%20manager%22#materials
 
   - name: RDNL - Essentials for Data Support

--- a/pages/your_role/data_steward_research.md
+++ b/pages/your_role/data_steward_research.md
@@ -11,27 +11,22 @@ training:
 
   - name: RDNL - Essentials for Data Support
     registry:
-    registry_url:
     url: https://datasupport.researchdata.nl/en/
 
   - name: Mantra - RDM training
     registry:
-    registry_url:
     url: https://mantra.edina.ac.uk/
 
   - name: GO FAIR starter kit
     registry:
-    registry_url:
     url: https://www.go-fair.org/resources/rdm-starter-kit/
 
   - name: Data Carpentry lessons
-    registry:
-    registry_url:
+    registry: Carpentries
     url: https://datacarpentry.org/lessons/
 
   - name: RDNL & DCC - Delivering RDM Services
     registry:
-    registry_url:
     url: https://www.futurelearn.com/courses/delivering-research-data-management-services
 
   - name: NPOS/ELIXIR data steward competency framework
@@ -40,7 +35,6 @@ training:
 
   - name: ELIXIR Data Management Network
     registry:
-    registry_url:
     url: https://elixir-europe.org/about-us/how-funded/eu-projects/converge/wp1/dm-coordinators
 ---
 

--- a/pages/your_role/data_steward_research.md
+++ b/pages/your_role/data_steward_research.md
@@ -6,8 +6,7 @@ related_pages:
   your_tasks: [compliance, DMP, data organisation, licensing, metadata, data protection, data publication, data quality, transfer, identifiers, machine actionability]
 training:
   - name: TeSS - ELIXIR’s training portal
-    registry: TeSS
-    registry_url: https://tess.elixir-europe.org/
+    registry: TeSS/
     url: https://tess.elixir-europe.org/search?q=%22data%20manager%22#materials
 
   - name: RDNL - Essentials for Data Support

--- a/pages/your_role/data_steward_research.md
+++ b/pages/your_role/data_steward_research.md
@@ -36,7 +36,6 @@ training:
 
   - name: NPOS/ELIXIR data steward competency framework
     registry: Zenodo
-    registry_url: https://zenodo.org
     url: https://zenodo.org/record/3490855#.YArTH-lKi7o
 
   - name: ELIXIR Data Management Network

--- a/pages/your_role/researcher.md
+++ b/pages/your_role/researcher.md
@@ -7,7 +7,6 @@ related_pages:
 training:
   - name: Training in TeSS
     registry: TeSS
-    registry_url: https://tess.elixir-europe.org
     url: https://tess.elixir-europe.org/search?q=Data%20Management%20Planning#materials
 ---
 

--- a/pages/your_tasks/TEMPLATE_your_tasks.md
+++ b/pages/your_tasks/TEMPLATE_your_tasks.md
@@ -8,7 +8,6 @@ related_pages:
 training:
   - name:
     registry:
-    registry_url:
     url:
 ---
 

--- a/pages/your_tasks/data_analysis.md
+++ b/pages/your_tasks/data_analysis.md
@@ -8,7 +8,6 @@ related_pages:
 training:
   - name: Training in TeSS
     registry: TeSS
-    registry_url: https://tess.elixir-europe.org
     url: https://tess.elixir-europe.org/search?q=%22data+analysis%22#materials
 dsw:
 - name: Did you choose the workflow engine you will be using?

--- a/pages/your_tasks/data_management_plan.md
+++ b/pages/your_tasks/data_management_plan.md
@@ -8,7 +8,6 @@ related_pages:
 training:
   - name: Training in TeSS
     registry: TeSS
-    registry_url: https://tess.elixir-europe.org
     url: https://tess.elixir-europe.org/search?q=%22data+management+plan%22#materials
 ---
 

--- a/pages/your_tasks/data_protection.md
+++ b/pages/your_tasks/data_protection.md
@@ -8,7 +8,6 @@ related_pages:
 training:
   - name: Training in TeSS
     registry: TeSS
-    registry_url: https://tess.elixir-europe.org
     url: https://tess.elixir-europe.org/search?q=data+protection#materials
 dsw:
 - name: Will you collect any data connected to a person, "personal data"?

--- a/pages/your_tasks/data_transfer.md
+++ b/pages/your_tasks/data_transfer.md
@@ -8,7 +8,6 @@ related_pages:
 training:
   - name: Training in TeSS
     registry: TeSS
-    registry_url: https://tess.elixir-europe.org
     url: https://tess.elixir-europe.org/search?q=%22data+transfer%22#materials
 dsw:
 - name: How will the raw data be transported?

--- a/pages/your_tasks/sensitive_data.md
+++ b/pages/your_tasks/sensitive_data.md
@@ -8,7 +8,6 @@ related_pages:
 training:
   - name: Training in TeSS
     registry: TeSS
-    registry_url: https://tess.elixir-europe.org
     url: https://tess.elixir-europe.org/search?q=%22sensitive+data%22#materials
 dsw:
 - name: Will you collect any data connected to a person, "personal data"?

--- a/pages/your_tasks/storage.md
+++ b/pages/your_tasks/storage.md
@@ -8,7 +8,6 @@ related_pages:
 training:
   - name: Training in TeSS
     registry: TeSS
-    registry_url: https://tess.elixir-europe.org
     url: https://tess.elixir-europe.org/search?q=%22data+storage%22#materials
 dsw:
 - name: Data storage systems and file naming conventions


### PR DESCRIPTION
Logo for zenodo, youtube and the carpentries:
![Screenshot from 2022-04-22 18-44-26](https://user-images.githubusercontent.com/44875756/164758960-29592b9a-01d2-4d02-93a2-08aed5002b1f.png)

more info on the options can be fount in this [PR of the theme](https://github.com/ELIXIR-Belgium/elixir-toolkit-theme/pull/68)

Also registry_url is not needed anymore, since it had not really a purpose