### PR TITLE
Update structural_bioinformatics.md

### DIFF
--- a/pages/your_domain/structural_bioinformatics.md
+++ b/pages/your_domain/structural_bioinformatics.md
@@ -1,7 +1,6 @@
 ---
 title: Structural Bioinformatics
 contributors: [Gerardo Tauriello, Ian Sillitoe, Nicola Bordin, Christine Orengo, Mihaly Varadi, Sameer Velankar, Jiří Černý]
-coordinators: [Gerardo Tauriello]
 page_id: struct bioinfo
 related_pages: 
   your_tasks: []


### PR DESCRIPTION
Remove "coordinators" metadata field, as decided during editorial meeting ("coordinators" only in National pages).