### PR TITLE
Popover grey + affiliation in firefox fix

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -4,7 +4,7 @@ title: RDMkit
 description: "Find the answers to your Research Data Management questions in Life Sciences."
 # Metadata description of the website
 
-remote_theme: ELIXIR-Belgium/elixir-toolkit-theme@1.15.2
+remote_theme: ELIXIR-Belgium/elixir-toolkit-theme@1.16.0
 
 sass:
   style: compressed

--- a/_sass/_custom_variables.scss
+++ b/_sass/_custom_variables.scss
@@ -1,32 +1,13 @@
 
 /*-----General styling-----*/
 $font-family-theme: "Exo 2", sans-serif;
-$h2-color: $primary;
-
-/*-----Buttons hover style-----*/
-$btn-primary-bg-hover: $primary;
-$btn-primary-color-hover: $white;
 
 /*-----Top navigation-----*/
 $topnav-bg: $dark;
-$topnav-title-color: $primary;
 $topnav-brand-height: 40px;
 
-/*-----Search-----*/
-$search-result-color: $primary;
-
-/*-----Sidebar-----*/
-$sidebar-bg: $light;
-$sidebar-color: $dark;
-$sidebar-lvl2-bg: $white;
-$sidebar-lvl2-color: $dark;
-$sidebar-lvl3-bg: $white;
-$sidebar-lvl3-color: $dark;
-$sidebar-bg-active: $primary;
-$sidebar-color-active: $white;
-
-/*-----TOC-----*/
-$toc-bg: $light;
+/*-----More information tiles-----*/
+$info-card-header-bg: $dark;
 
 /*-----Section navigation tiles-----*/
 $nav-card-bg: $light;
@@ -34,39 +15,11 @@ $nav-card-header-bg: $dark;
 $nav-card-header-color: $white;
 $nav-card-badge-color: $body-color;
 $nav-card-badge-bg: $white;
-$nav-card-badge-color-hover: $white;
-$nav-card-badge-bg-hover: $primary;
-
-/*-----More information tiles-----*/
-$info-card-bg: $light;
-$info-card-header-bg: $dark;
-$info-card-header-color: $white;
-
-/*-----Contributors-cards-----*/
-$contr-card-bg: $light;
-
-/*-----Page contributors-----*/
-$contr-bg: $light;
-$contr-link-bg: $white;
-$contr-crown-bg: $dark;
-$contr-crown-color: $white;
-
-/*-----Events & news-----*/
-$news-title-bg: $primary;
-$news-border-color: $light;
-$news-title-color: $white;
-
-/*-----Default badge-----*/
-$badge-color: $body-color;
-$badge-bg: $light;
-$badge-color-hover: $white;
-$badge-bg-hover: $primary;
 
 /*-----Footer-----*/
 $footer-bg: $dark;
 $footer-color: $white;
 $footer-link-color: $white;
-$footer-link-color-hover: $primary;
 $footer-copyright-bg: #00000033;
 
 


### PR DESCRIPTION
- Making use of latest version theme
- Fix for affiliation tiles where svgs without width are not shown
- Less hard contributor popover footer, making use of the same color as in the contributor panels:
 ![Screenshot from 2022-05-27 17-34-33](https://user-images.githubusercontent.com/44875756/170732762-471093be-e57b-4533-bf2d-0684934d97bc.png)
 