### PR TITLE
RDMkit FAIR Cookbook links

### DIFF
--- a/pages/contribute/editorial_board_guide.md
+++ b/pages/contribute/editorial_board_guide.md
@@ -232,7 +232,7 @@ related_pages:
 To find out what the `page_id` of an RDMkit page is, please check its metadata attribute `page_id` at the top of the markdown file or the [Website overview page](website_overview).
 
 
-### Links between RDMkit and FAIR Cookbook
+### Linking from RDMkit to FAIR Cookbook
 
 - Links between RDMkit and FAIR Cookbook are described in the `faircookbook_rdmkit_mapping.yml` file located in the [faircookbook-rdmkit repository](https://github.com/elixir-europe/faircookbook-rdmkit).
 - After adding the links create a PR. The PR should be reviewed and approved by at least one editor from both teams.

--- a/pages/contribute/editorial_board_guide.md
+++ b/pages/contribute/editorial_board_guide.md
@@ -234,7 +234,7 @@ To find out what the `page_id` of an RDMkit page is, please check its metadata a
 
 ### Links between RDMkit and FAIR Cookbook
 
-- To register links between the RDMkit pages  and FAIR Cookbook recipies enter the links in the faircookbook_rdmkit_mapping.yml file. The .yml is placed in the [repository](https://github.com/elixir-europe/faircookbook-rdmkit).
+- Links between RDMkit and FAIR Cookbook are described in the `faircookbook_rdmkit_mapping.yml` file located in the [faircookbook-rdmkit repository](https://github.com/elixir-europe/faircookbook-rdmkit).
 - After adding the links create a PR. The PR should be reviewd and approved by atleast one editor from both teams.
 - After the approval from editors Fair Cookbook and RDMkit will automatically pull changes from the central .yml file to update there repository. The process of merging the changes to the main branch from the reposiory takes place weekly.
 

--- a/pages/contribute/editorial_board_guide.md
+++ b/pages/contribute/editorial_board_guide.md
@@ -230,3 +230,11 @@ related_pages:
 ### Page ID
 
 To find out what the `page_id` of an RDMkit page is, please check its metadata attribute `page_id` at the top of the markdown file or the [Website overview page](website_overview).
+
+
+### Links between RDMkit and FAIR Cookbook
+
+- To register links between the RDMkit pages  and FAIR Cookbook recipies enter the links in the faircookbook_rdmkit_mapping.yml file. The .yml is placed in the [repository](https://github.com/elixir-europe/faircookbook-rdmkit).
+- After adding the links create a PR. The PR should be reviewd and approved by atleast one editor from both teams.
+- After the approval from editors Fair Cookbook and RDMkit will automatically pull changes from the central .yml file to update there repository. The process of merging the changes to the main branch from the reposiory takes place weekly.
+

--- a/pages/contribute/editorial_board_guide.md
+++ b/pages/contribute/editorial_board_guide.md
@@ -235,6 +235,6 @@ To find out what the `page_id` of an RDMkit page is, please check its metadata a
 ### Links between RDMkit and FAIR Cookbook
 
 - Links between RDMkit and FAIR Cookbook are described in the `faircookbook_rdmkit_mapping.yml` file located in the [faircookbook-rdmkit repository](https://github.com/elixir-europe/faircookbook-rdmkit).
-- After adding the links create a PR. The PR should be reviewd and approved by atleast one editor from both teams.
+- After adding the links create a PR. The PR should be reviewed and approved by at least one editor from both teams.
 - After the approval from editors Fair Cookbook and RDMkit will automatically pull changes from the central .yml file to update there repository. The process of merging the changes to the main branch from the reposiory takes place weekly.
 


### PR DESCRIPTION
Added instructions for creating RDMkit-FAIR Cookbook links in Editorial board guide page as a subsection under the Related pages. @bedroesb could you please check if this is the accurate description