### PR TITLE
Switch DSW links to Researchers instance

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -13,7 +13,7 @@ sass:
 gtag: G-RXQ55EFTTH
 # Google analytics tag
 
-dsw_deep_link_prefix: https://converge.ds-wizard.org/knowledge-models/dsw:root:latest/preview?questionUuid=
+dsw_deep_link_prefix: https://researchers.ds-wizard.org/knowledge-models/dsw:root:latest/preview?questionUuid=
 # prefix for DSW deep links to a certain question
 
 theme_variables:

--- a/var/dsw_integration.py
+++ b/var/dsw_integration.py
@@ -13,7 +13,7 @@ import yaml
 rootdir = 'pages/'
 DSWQuestion = collections.namedtuple('DSWQuestion', 'uuid, text')
 RDMKIT_PREFIX = 'https://rdmkit.elixir-europe.org'
-DSW_API_URL = 'https://api-converge.ds-wizard.org'
+DSW_API_URL = 'https://api-researchers.ds-wizard.org'
 DSW_KM_ID = 'dsw:root:latest'
 
 # --------- Functions ---------


### PR DESCRIPTION
Instead of [converge.ds-wizard.org](https://converge.ds-wizard.org) we should switch to using [researcher<b>s</b>.ds-wizard.org](https://researchers.ds-wizard.org) as the _main_ instance to be used.