### PR TITLE
Adding persistent identifiers based on page_id

### DIFF
--- a/pages/data_life_cycle/TEMPLATE_rdm_cycle.md
+++ b/pages/data_life_cycle/TEMPLATE_rdm_cycle.md
@@ -4,7 +4,7 @@ contributors: [<!---REPLACE THIS with comma separated list of contributors--->]
 search_exclude: true
 description: <!---REPLACE THIS with a one sentence description of the page--->
 page_id: <!---REPLACE THIS with a shortened page name, with small letters and spaces, or an acronym in capital and small letters--->
-redirect_from: /pid/<!---REPLACE THIS with a shortened page name, with small letters and spaces, or an acronym in capital and small letters--->
+redirect_from: /pid/<!---REPLACE THIS with page_id--->
 related_pages: 
   your_tasks: [<!---REPLACE THIS with the page ID of the your_tasks pages that you want to list here as related pages--->]
 training:

--- a/pages/data_life_cycle/TEMPLATE_rdm_cycle.md
+++ b/pages/data_life_cycle/TEMPLATE_rdm_cycle.md
@@ -4,6 +4,7 @@ contributors: [<!---REPLACE THIS with comma separated list of contributors--->]
 search_exclude: true
 description: <!---REPLACE THIS with a one sentence description of the page--->
 page_id: <!---REPLACE THIS with a shortened page name, with small letters and spaces, or an acronym in capital and small letters--->
+redirect_from: /pid/<!---REPLACE THIS with a shortened page name, with small letters and spaces, or an acronym in capital and small letters--->
 related_pages: 
   your_tasks: [<!---REPLACE THIS with the page ID of the your_tasks pages that you want to list here as related pages--->]
 training:

--- a/pages/data_life_cycle/analysing.md
+++ b/pages/data_life_cycle/analysing.md
@@ -1,6 +1,7 @@
 ---
 title: Analysing
 page_id: analyse
+redirect_from: /pid/analyse
 related_pages: 
   your_tasks: [data analysis, data organisation, storage]
 contributors: [Rob Hooft, Olivier Collin, Munazah Andrabi, Flora D'Anna]

--- a/pages/data_life_cycle/collecting.md
+++ b/pages/data_life_cycle/collecting.md
@@ -1,6 +1,7 @@
 ---
 title: Collecting
 page_id: collect
+redirect_from: /pid/collect
 description: Data management at the data collection stage
 related_pages: 
   your_tasks: [data organisation, data quality, existing data, identifiers, metadata, sensitive, storage]

--- a/pages/data_life_cycle/planning.md
+++ b/pages/data_life_cycle/planning.md
@@ -1,6 +1,7 @@
 ---
 title: Planning
 page_id: plan
+redirect_from: /pid/plan
 description: Introduction to data management planning
 contributors: [Siiri Fuchs, Korbinian Bösl, Minna Ahokas, Federico Bianchini, Flora D'Anna]
 related_pages: 

--- a/pages/data_life_cycle/preserving.md
+++ b/pages/data_life_cycle/preserving.md
@@ -1,6 +1,7 @@
 ---
 title: Preserving
 page_id: preserve
+redirect_from: /pid/preserve
 description: Introduction to data preservation
 contributors: [Siiri Fuchs, Korbinian Bösl, Anastasia Chasapi, Flora D'Anna]
 related_pages: 

--- a/pages/data_life_cycle/processing.md
+++ b/pages/data_life_cycle/processing.md
@@ -1,6 +1,7 @@
 ---
 title: Processing
 page_id: process
+redirect_from: /pid/process
 description: How to manage the data processing stage
 contributors: [Rob Hooft, Munazah Andrabi]
 related_pages: 

--- a/pages/data_life_cycle/reusing.md
+++ b/pages/data_life_cycle/reusing.md
@@ -1,6 +1,7 @@
 ---
 title: Reusing
 page_id: reuse
+redirect_from: /pid/reuse
 description: Introduction to data reuse
 contributors: [Korbinian Bösl, Daniel Faria, Markus Englund]
 related_pages: 

--- a/pages/data_life_cycle/sharing.md
+++ b/pages/data_life_cycle/sharing.md
@@ -1,6 +1,7 @@
 ---
 title: Sharing
 page_id: share
+redirect_from: /pid/share
 description: Introduction to data sharing
 contributors: [Flora D'Anna, Bert Droesbeke, Niclas Jareborg, Ulrike Wittig]
 related_pages: 

--- a/pages/tool_assembly/TEMPLATE_tool_assembly.md
+++ b/pages/tool_assembly/TEMPLATE_tool_assembly.md
@@ -5,6 +5,7 @@ contributors: [<!---REPLACE THIS with comma separated list of contributors--->]
 description: <!---REPLACE THIS with a very short summary (one sentence) this should include if there are limitiations for the audience--->
 affiliations: [<!---REPLACE THIS with comma separated list of affiliations. Countries use the ISO 3166-1-alpha-2 notation, other affiliations must be present in the affiliations.yaml in the _data directory in order to work--->]
 page_id: <!---REPLACE THIS with a shortened page name, with small letters and spaces, or an acronym in capital and small letters--->
+redirect_from: /pid/<!---REPLACE THIS with a shortened page name, with small letters and spaces, or an acronym in capital and small letters--->
 related_pages: 
   your_tasks: [<!---REPLACE THIS with the page ID of the your_tasks pages that you want to list here as related pages--->]
   your_domain: [<!---REPLACE THIS with the page ID of the your_domain pages that you want to list here as related pages--->]

--- a/pages/tool_assembly/TEMPLATE_tool_assembly.md
+++ b/pages/tool_assembly/TEMPLATE_tool_assembly.md
@@ -5,7 +5,7 @@ contributors: [<!---REPLACE THIS with comma separated list of contributors--->]
 description: <!---REPLACE THIS with a very short summary (one sentence) this should include if there are limitiations for the audience--->
 affiliations: [<!---REPLACE THIS with comma separated list of affiliations. Countries use the ISO 3166-1-alpha-2 notation, other affiliations must be present in the affiliations.yaml in the _data directory in order to work--->]
 page_id: <!---REPLACE THIS with a shortened page name, with small letters and spaces, or an acronym in capital and small letters--->
-redirect_from: /pid/<!---REPLACE THIS with a shortened page name, with small letters and spaces, or an acronym in capital and small letters--->
+redirect_from: /pid/<!---REPLACE THIS with page_id--->
 related_pages: 
   your_tasks: [<!---REPLACE THIS with the page ID of the your_tasks pages that you want to list here as related pages--->]
   your_domain: [<!---REPLACE THIS with the page ID of the your_domain pages that you want to list here as related pages--->]

--- a/pages/tool_assembly/covid19_data_portal.md
+++ b/pages/tool_assembly/covid19_data_portal.md
@@ -2,6 +2,7 @@
 title: COVID-19 Data Portal 
 contributors: [Guy Cochrane, Marianna Ventouratou, Nadim Rahman, Sam Holt]
 page_id: Covid-19
+redirect_from: /pid/Covid-19
 affiliations: [ELIXIR CONVERGE]
 related_pages:
   your_tasks: [sensitive, existing data, data publication]

--- a/pages/tool_assembly/csc_assembly.md
+++ b/pages/tool_assembly/csc_assembly.md
@@ -3,6 +3,7 @@ title: CSC
 contributors: [Siiri Fuchs, Minna Ahokas]
 description: The Center of Science (CSC) provides high-quality ICT expert services for researchers in Finland and their collaborators.
 page_id: CSC
+redirect_from: /pid/CSC
 affiliations: [FI, CSC, ELIXIR Europe]
 related_pages: 
   your_tasks: [sensitive, DMP, data protection, storage, data publication, data transfer, data analysis]

--- a/pages/tool_assembly/galaxy_assembly.md
+++ b/pages/tool_assembly/galaxy_assembly.md
@@ -3,6 +3,7 @@ title: Galaxy
 contributors: [Amandine Nunes-Jorge, Beatriz Serrano-Solano]
 description: Galaxy is an open, web-based platform for accessible, reproducible, and transparent computational research.
 page_id: galaxy
+redirect_from: /pid/galaxy
 affiliations: [ELIXIR Europe, "European Union"]
 related_pages: 
   your_tasks: [data analysis, data organisation, data publication, data quality, data transfer, existing data, identifiers, machine actionability, metadata]

--- a/pages/tool_assembly/ifb_assembly.md
+++ b/pages/tool_assembly/ifb_assembly.md
@@ -3,6 +3,7 @@ title: IFB
 contributors: [Olivier Collin, Marie-Christine Jacquemot, Paulette Lieby, Flora D'Anna]
 description: The French Bioinformatics Institute (IFB) offers IT infrastructure and bioinformatics expertise to support researchers in Life Sciences.
 page_id: IFB
+redirect_from: /pid/IFB
 affiliations: ["ELIXIR Europe", "FR"]
 related_pages: 
   your_tasks: [DMP, data organisation ,storage, data publication, data transfer, metadata, data analysis]

--- a/pages/tool_assembly/marine_metagenomics_assembly.md
+++ b/pages/tool_assembly/marine_metagenomics_assembly.md
@@ -3,6 +3,7 @@ title: Marine Metagenomics
 contributors: [Nazeefa Fatima, Espen Åberg,  Nils Peder Willassens]
 description: The Marine Metagenomics tool assembly aims to provide a comprehensive data management toolkit of marine genomics researchers in Norway.
 page_id: marine assembly
+redirect_from: /pid/marine assembly
 affiliations: [ELIXIR Europe, "NO"]
 related_pages:
   your_tasks: [DMP, existing data, data organisation ,storage, data publication, data transfer, metadata, data analysis]

--- a/pages/tool_assembly/nels_assembly.md
+++ b/pages/tool_assembly/nels_assembly.md
@@ -3,6 +3,7 @@ title: NeLS
 contributors: [Korbinian Bösl, Federico Bianchini, Erik Hjerde]
 description: NeLS provides the necessary tools for data management aimed for researchers in Norway and their collaborators.
 page_id: NeLS
+redirect_from: /pid/NeLS
 affiliations: ["ELIXIR Europe", "NO"]
 related_pages: 
   your_tasks: [DMP, data organisation ,storage, data publication, data transfer, metadata]

--- a/pages/tool_assembly/omero_assembly.md
+++ b/pages/tool_assembly/omero_assembly.md
@@ -2,6 +2,7 @@
 title: OMERO
 contributors: [Jean-Marie Burel] 
 page_id: ome
+redirect_from: /pid/ome
 affiliations: [Euro BioImaging]
 related_pages: 
   your_tasks: [data organisation, storage, data analysis]

--- a/pages/tool_assembly/plant_genomics_assembly.md
+++ b/pages/tool_assembly/plant_genomics_assembly.md
@@ -3,6 +3,7 @@ title: Plant Genomics
 contributors: [Anne-Françoise Adam-Blondon, Cyril Pommier, Daniel Faria, Paulette Lieby, Sebastian Beier, Erwan Le Floch]
 description: Tool assembly for managing plant genomic data.
 page_id: plant geno assembly
+redirect_from: /pid/plant geno assembly
 affiliations:
 related_pages: 
   your_tasks: [metadata, data publication]

--- a/pages/tool_assembly/plant_phenomics_assembly.md
+++ b/pages/tool_assembly/plant_phenomics_assembly.md
@@ -3,6 +3,7 @@ title: Plant Phenomics
 contributors: [Anne-Françoise Adam-Blondon, Cyril Pommier, Bert Droesbeke, Matthias Lange, Daniel Arend, Daniel Faria, Isabelle Alic, Philippe Rocca-Serra, Sebastian Beier, Erwan Le Floch]
 description: Tool assembly for managing plant phenomic data.
 page_id: plant pheno assembly
+redirect_from: /pid/plant pheno assembly
 affiliations:
 related_pages: 
   your_tasks: [metadata, data publication]

--- a/pages/tool_assembly/transmed_assembly.md
+++ b/pages/tool_assembly/transmed_assembly.md
@@ -3,6 +3,7 @@ title: TransMed
 contributors: [Wei Gu, Soumyabrata Ghosh, Muhammad Shoaib, Irina Balaur, Xinhui Wang, Carlos Vega, Pinar Alper, Venkata Satagopam]
 description: TransMed from ELIXIR Luxembourg supports projects in Translational Biomedicine for clinical and translational projects.
 page_id: transmed
+redirect_from: /pid/transmed
 affiliations: [ELIXIR Europe, LU]
 related_pages: 
   your_tasks: [compliance, storage, metadata, data organisation, data analysis, sensitive, data protection, DMP]

--- a/pages/tool_assembly/tsd_assembly.md
+++ b/pages/tool_assembly/tsd_assembly.md
@@ -3,6 +3,7 @@ title: TSD
 contributors: [Tina Visnovska, Federico Bianchini, Korbinian Bösl]
 description: The Sensitive Data Service (TSD) provides a platform to store, compute and analyse research sensitive data in compliance with Norwegian regulations regarding individuals’ privacy.
 page_id: TSD
+redirect_from: /pid/TSD
 affiliations: ["NO", ELIXIR Europe, University of Oslo]
 related_pages: 
   your_tasks: [DMP, storage, sensitive, data protection, transfer]

--- a/pages/tool_assembly/xnat_pic_assembly.md
+++ b/pages/tool_assembly/xnat_pic_assembly.md
@@ -2,6 +2,7 @@
 title: XNAT-PIC
 contributors: [Sara Zullino, Alessandro Paglialonga, Walter Dastrù, Dario Longo, Silvio Aime]
 page_id: XNAT-PIC
+redirect_from: /pid/XNAT-PIC
 affiliations: [Euro BioImaging, IT]
 related_pages: 
   your_tasks: [data organisation, storage, data analysis]

--- a/pages/your_domain/TEMPLATE_your_domain.md
+++ b/pages/your_domain/TEMPLATE_your_domain.md
@@ -4,7 +4,7 @@ search_exclude: true
 description: <!---REPLACE THIS with a one sentence description of the page--->
 contributors: [<!---REPLACE THIS with comma separated list of contributors--->]
 page_id: <!---REPLACE THIS with a shortened page name, with small letters and spaces, or an acronym in capital and small letters--->
-redirect_from: /pid/<!---REPLACE THIS with a shortened page name, with small letters and spaces, or an acronym in capital and small letters--->
+redirect_from: /pid/<!---REPLACE THIS with page_id--->
 related_pages: 
   your_tasks: [<!---REPLACE THIS with the page ID of the your_tasks pages that you want to list here as related pages--->]
   tool_assembly: [<!---REPLACE THIS with the page ID of the tool_assembly pages that you want to list here as related pages--->]

--- a/pages/your_domain/TEMPLATE_your_domain.md
+++ b/pages/your_domain/TEMPLATE_your_domain.md
@@ -4,6 +4,7 @@ search_exclude: true
 description: <!---REPLACE THIS with a one sentence description of the page--->
 contributors: [<!---REPLACE THIS with comma separated list of contributors--->]
 page_id: <!---REPLACE THIS with a shortened page name, with small letters and spaces, or an acronym in capital and small letters--->
+redirect_from: /pid/<!---REPLACE THIS with a shortened page name, with small letters and spaces, or an acronym in capital and small letters--->
 related_pages: 
   your_tasks: [<!---REPLACE THIS with the page ID of the your_tasks pages that you want to list here as related pages--->]
   tool_assembly: [<!---REPLACE THIS with the page ID of the tool_assembly pages that you want to list here as related pages--->]

--- a/pages/your_domain/bioimaging_data.md
+++ b/pages/your_domain/bioimaging_data.md
@@ -3,6 +3,7 @@ title: Bioimaging data
 description: Data management solutions for bioimaging data
 contributors: [Sébastien Besson, Jean-Marie Burel, Susanne Kunis, Josh Moore, Stefanie Weidtkamp-Peters]
 page_id: bioimaging data
+redirect_from: /pid/bioimaging data
 related_pages: 
   your_tasks: [DMP, data organisation, data publication, existing data, transfer, licensing, metadata, storage]
   tool_assembly: [ome, XNAT-PIC]

--- a/pages/your_domain/biomolecular_simulation_data.md
+++ b/pages/your_domain/biomolecular_simulation_data.md
@@ -1,6 +1,7 @@
 ---
 title: Biomolecular simulation data
 page_id: biomol sim
+redirect_from: /pid/biomol sim
 description: Data management solutions for biomolecular simulation data
 contributors: [Karel Berka, Adam Hospital]
 related_pages:

--- a/pages/your_domain/epitranscriptome_data.md
+++ b/pages/your_domain/epitranscriptome_data.md
@@ -3,6 +3,7 @@ title: Epitranscriptome data
 description: Data management solutions for epitranscriptome data
 contributors: [Ernesto Picardi, Laura Portell Silva]
 page_id: epitrans
+redirect_from: /pid/epitrans
 related_pages: 
   your_tasks: []
   tool_assembly: []

--- a/pages/your_domain/human_data.md
+++ b/pages/your_domain/human_data.md
@@ -3,6 +3,7 @@ title: Human data
 description: Data management solutions for human data
 contributors: [Niclas Jareborg, Nirupama Benis, Ana Portugal Melo, Pinar Alper, Laura Portell Silva, Wolmar Nyberg Åkerström, Nazeefa Fatima]
 page_id: human data
+redirect_from: /pid/human data
 related_pages:
   your_tasks: [sensitive]
   tool_assembly: [TSD, Covid-19, transmed]

--- a/pages/your_domain/intrinsically_disordered_proteins.md
+++ b/pages/your_domain/intrinsically_disordered_proteins.md
@@ -4,6 +4,7 @@ description: Data management solutions for intrinsically disordered proteins dat
 contributors: [Ivan Mičetić]
 related_pages: 
 page_id: IDP
+redirect_from: /pid/IDP
 related_pages: 
   your_tasks: [metadata]
   tool_assembly: []

--- a/pages/your_domain/marine_metagenomics.md
+++ b/pages/your_domain/marine_metagenomics.md
@@ -4,6 +4,7 @@ description: Data management solutions for marine metagenomics data
 contributors: [Nils Peder Willassen,Anastasis Oulas,Evangelos Pafilis]
 related_pages: 
 page_id: marine
+redirect_from: /pid/marine
 related_pages: 
   your_tasks: [metadata]
   tool_assembly: [marine assembly]

--- a/pages/your_domain/microbial_biotechnology.md
+++ b/pages/your_domain/microbial_biotechnology.md
@@ -3,6 +3,7 @@ title: Microbial biotechnology
 description: Data management solutions for microbial biotechnology data
 contributors: [Anil Wipat, David Markham, Christian Atallah, Bradley Brown, Munazah Andrabi]
 page_id: micro biotech
+redirect_from: /pid/micro biotech
 related_pages: 
   your_tasks: []
   tool_assembly: []

--- a/pages/your_domain/plant_sciences.md
+++ b/pages/your_domain/plant_sciences.md
@@ -4,6 +4,7 @@ description: Data management solutions for plant sciences data
 contributors: [Anne-Françoise Adam-Blondon, Sebastian Beier, Cyril Pommier, Erwan Le Floch, Daniel Faria]
 related_pages: 
 page_id: plants
+redirect_from: /pid/plants
 related_pages: 
   your_tasks: [metadata]
   tool_assembly: [plant geno assembly, plant pheno assembly]

--- a/pages/your_domain/proteomics.md
+++ b/pages/your_domain/proteomics.md
@@ -3,6 +3,7 @@ title: Proteomics
 description: Data management solutions for proteomics data
 contributors: [Michael Turewicz, Martin Eisenacher, Anika Frericks-Zipper, Ulrike Wittig]
 page_id: proteomics
+redirect_from: /pid/proteomics
 related_pages:
   your_tasks: [metadata]
   tool_assembly: []

--- a/pages/your_domain/rare_disease_data.md
+++ b/pages/your_domain/rare_disease_data.md
@@ -3,6 +3,7 @@ title: Rare disease data
 description: Data management solutions for rare disease data
 contributors: [Philip van Damme, Nirupama Benis, César Bernabé, Shuxin Zhang, Alberto Camara Ballesteros, Bruna Dos Santos Vieira, Munazah Andrabi]
 page_id: rare disease
+redirect_from: /pid/rare disease
 related_pages: 
   your_domain: [human data]
   your_tasks: [DMP, data publication, machine actionability]

--- a/pages/your_domain/structural_bioinformatics.md
+++ b/pages/your_domain/structural_bioinformatics.md
@@ -3,6 +3,7 @@ title: Structural Bioinformatics
 description: Data management solutions for structural bioinformatics data
 contributors: [Gerardo Tauriello, Ian Sillitoe, Nicola Bordin, Christine Orengo, Mihaly Varadi, Sameer Velankar, Jiří Černý]
 page_id: struct bioinfo
+redirect_from: /pid/struct bioinfo
 related_pages: 
   your_tasks: []
   tool_assembly: []

--- a/pages/your_domain/toxicology_data.md
+++ b/pages/your_domain/toxicology_data.md
@@ -3,6 +3,7 @@ title: Toxicology data
 description: Data management solutions for toxicology data
 contributors: [Manuel Pastor, Janet Piñero Gonzalez, Juan Manuel Ramírez-Anguita, Ferran Sanz, Miguel Angel Mayer, Laura Portell Silva]
 page_id: toxicology data
+redirect_from: /pid/toxicology data
 related_pages: 
   your_tasks: [data analysis]
   tool_assembly: []

--- a/pages/your_role/TEMPLATE_your_role.md
+++ b/pages/your_role/TEMPLATE_your_role.md
@@ -4,6 +4,7 @@ search_exclude: true
 description: <!---REPLACE THIS with a one sentence description of the page--->
 contributors: [<!---REPLACE THIS with comma separated list of contributors--->]
 page_id: <!---REPLACE THIS with a shortened page name, with small letters and spaces, or an acronym in capital and small letters--->
+redirect_from: /pid/<!---REPLACE THIS with a shortened page name, with small letters and spaces, or an acronym in capital and small letters--->
 related_pages: 
   your_tasks: [<!---REPLACE THIS with the page ID of the your_tasks pages that you want to list here as related pages--->]
 training:

--- a/pages/your_role/TEMPLATE_your_role.md
+++ b/pages/your_role/TEMPLATE_your_role.md
@@ -4,7 +4,7 @@ search_exclude: true
 description: <!---REPLACE THIS with a one sentence description of the page--->
 contributors: [<!---REPLACE THIS with comma separated list of contributors--->]
 page_id: <!---REPLACE THIS with a shortened page name, with small letters and spaces, or an acronym in capital and small letters--->
-redirect_from: /pid/<!---REPLACE THIS with a shortened page name, with small letters and spaces, or an acronym in capital and small letters--->
+redirect_from: /pid/<!---REPLACE THIS with page_id--->
 related_pages: 
   your_tasks: [<!---REPLACE THIS with the page ID of the your_tasks pages that you want to list here as related pages--->]
 training:

--- a/pages/your_role/data_steward_infrastructure.md
+++ b/pages/your_role/data_steward_infrastructure.md
@@ -3,6 +3,7 @@ title: "Data Steward: infrastructure"
 description: Data Steward with focus on tools (software) and IT infrastructure for data management
 contributors: [Mijke Jetten, Federico Bianchini, Gregoire Rossier, Erik Hjerde, Siiri Fuchs, Minna Ahokas, Priit Adler, Alexander Botzki, Robert Andrews, Celia van Gelder, Daniel Wibberg, Graham Hughes, Marko Vidak, Pedro Fernandes, Pinar Alper, Victoria Dominguez D. Angel, Wolmar Nyberg Åkerström, Alexia Cardona]
 page_id: IT support
+redirect_from: /pid/IT support
 related_pages: 
   your_tasks: [data analysis, data protection, data brokering, transfer, identifiers, storage, data organisation, machine actionability, DM coordination]
 training:

--- a/pages/your_role/data_steward_policy.md
+++ b/pages/your_role/data_steward_policy.md
@@ -3,6 +3,7 @@ title: "Data Steward: policy"
 description: Data Steward with focus on data policies
 contributors: [Mijke Jetten, Federico Bianchini, Gregoire Rossier, Erik Hjerde, Siiri Fuchs, Minna Ahokas, Priit Adler, Alexander Botzki, Robert Andrews, Celia van Gelder, Daniel Wibberg, Graham Hughes, Marko Vidak, Pedro Fernandes, Pinar Alper, Victoria Dominguez D. Angel, Wolmar Nyberg Åkerström, Alexia Cardona]
 page_id: policy officer
+redirect_from: /pid/policy officer
 related_pages: 
   your_tasks: [compliance, licensing, DMP, data protection, sensitive, DM coordination]
 training:

--- a/pages/your_role/data_steward_research.md
+++ b/pages/your_role/data_steward_research.md
@@ -3,6 +3,7 @@ title: "Data Steward: research"
 description: Data Steward with focus on management of research data
 contributors: [Mijke Jetten, Federico Bianchini, Gregoire Rossier, Erik Hjerde, Siiri Fuchs, Minna Ahokas, Priit Adler, Alexander Botzki, Robert Andrews, Celia van Gelder, Daniel Wibberg, Graham Hughes, Marko Vidak, Pedro Fernandes, Pinar Alper, Victoria Dominguez D. Angel, Wolmar Nyberg Åkerström, Alexia Cardona]
 page_id: data manager
+redirect_from: /pid/data manager
 related_pages: 
   your_tasks: [compliance, DMP, data organisation, licensing, metadata, data protection, data publication, data quality, transfer, identifiers, machine actionability, DM coordination]
 training:

--- a/pages/your_role/researcher.md
+++ b/pages/your_role/researcher.md
@@ -3,6 +3,7 @@ title: Researcher
 description: Researchers generating and reusing data
 contributors: [Mijke Jetten, Federico Bianchini, Gregoire Rossier, Erik Hjerde, Siiri Fuchs, Minna Ahokas, Priit Adler, Alexander Botzki, Robert Andrews, Celia van Gelder, Daniel Wibberg, Graham Hughes, Marko Vidak, Pedro Fernandes, Pinar Alper, Victoria Dominguez D. Angel, Wolmar Nyberg Åkerström, Alexia Cardona, Munazah Andrabi]
 page_id: researcher
+redirect_from: /pid/researcher
 related_pages: 
   your_tasks: [data analysis, DMP, data organisation, data publication, data quality, existing data, metadata, identifiers]
 training:

--- a/pages/your_tasks/TEMPLATE_your_tasks.md
+++ b/pages/your_tasks/TEMPLATE_your_tasks.md
@@ -4,6 +4,7 @@ search_exclude: true
 description: <!---REPLACE THIS with a one sentence description of the page--->
 contributors: [<!---REPLACE THIS with comma separated list of contributors--->]
 page_id: <!---REPLACE THIS with a shortened page name, with small letters and spaces, or an acronym in capital and small letters--->
+redirect_from: /pid/<!---REPLACE THIS with a shortened page name, with small letters and spaces, or an acronym in capital and small letters--->
 related_pages: 
   tool_assembly: [<!---REPLACE THIS with the page ID of the tool_assembly pages that you want to list here as related pages--->]
 training:

--- a/pages/your_tasks/TEMPLATE_your_tasks.md
+++ b/pages/your_tasks/TEMPLATE_your_tasks.md
@@ -4,7 +4,7 @@ search_exclude: true
 description: <!---REPLACE THIS with a one sentence description of the page--->
 contributors: [<!---REPLACE THIS with comma separated list of contributors--->]
 page_id: <!---REPLACE THIS with a shortened page name, with small letters and spaces, or an acronym in capital and small letters--->
-redirect_from: /pid/<!---REPLACE THIS with a shortened page name, with small letters and spaces, or an acronym in capital and small letters--->
+redirect_from: /pid/<!---REPLACE THIS with page_id--->
 related_pages: 
   tool_assembly: [<!---REPLACE THIS with the page ID of the tool_assembly pages that you want to list here as related pages--->]
 training:

--- a/pages/your_tasks/compliance_monitoring.md
+++ b/pages/your_tasks/compliance_monitoring.md
@@ -3,6 +3,7 @@ title: Compliance monitoring & measurement
 contributors: [Christophe Trefois, Wei Gu, Pinar Alper, Markus Englund, Vera Ortseifen]
 description: Measure compliance to data management regulations and standards
 page_id: compliance
+redirect_from: /pid/compliance
 related_pages:
   tool_assembly: [transmed]
 faircookbook:

--- a/pages/your_tasks/data_analysis.md
+++ b/pages/your_tasks/data_analysis.md
@@ -3,6 +3,7 @@ title: Data analysis
 contributors: [Olivier Collin, Stian Soiland-Reyes, Michael R. Crusoe]
 description: How to make data analysis FAIR
 page_id: data analysis
+redirect_from: /pid/data analysis
 related_pages:
   tool_assembly: [NeLS, XNAT-PIC, transmed, ome]
 training:

--- a/pages/your_tasks/data_brokering.md
+++ b/pages/your_tasks/data_brokering.md
@@ -3,6 +3,7 @@ title: Data brokering
 contributors: [Aitana Neves, Parul Tewatia, Wolmar Nyberg Åkerström, Carla Cummins, Nils Peder Willassen, Nazeefa Fatima]
 description: Information on brokering data to data repositories on behalf of data producers
 page_id: data brokering
+redirect_from: /pid/data brokering
 training:
   - name: Training in TeSS
     registry: TeSS

--- a/pages/your_tasks/data_management_plan.md
+++ b/pages/your_tasks/data_management_plan.md
@@ -3,6 +3,7 @@ title: Data management plan
 contributors: [Flora D'Anna, Daniel Faria]
 description: How to write a Data Management Plan (DMP)
 page_id: DMP
+redirect_from: /pid/DMP
 related_pages: 
   tool_assembly: [NeLS, TSD]
 training:

--- a/pages/your_tasks/data_organisation.md
+++ b/pages/your_tasks/data_organisation.md
@@ -3,6 +3,7 @@ title: Data organisation
 contributors: [Siiri Fuchs, Minna Ahokas, Yvonne Kallberg]
 description: Best practices to name and organise research data
 page_id: data organisation
+redirect_from: /pid/data organisation
 related_pages: 
   tool_assembly: [ome, transmed, XNAT-PIC]
 dsw:

--- a/pages/your_tasks/data_protection.md
+++ b/pages/your_tasks/data_protection.md
@@ -3,6 +3,7 @@ title: Data protection
 contributors: [Pinar Alper]
 description: How to make research data compliant to GDPR
 page_id: data protection
+redirect_from: /pid/data protection
 related_pages: 
   tool_assembly: [TSD, transmed]
 training:

--- a/pages/your_tasks/data_publication.md
+++ b/pages/your_tasks/data_publication.md
@@ -3,6 +3,7 @@ title: Data publication
 contributors: [Munazah Andrabi, Ulrike Wittig, Elin Kronander, Flora D'Anna, Aitana Neves, Nazeefa Fatima, Carla Cummins]
 description: Prepare data and find repositories for publication
 page_id: data publication
+redirect_from: /pid/data publication
 related_pages: 
     tool_assembly: []
 faircookbook:

--- a/pages/your_tasks/data_quality.md
+++ b/pages/your_tasks/data_quality.md
@@ -3,6 +3,7 @@ title: Data quality
 contributors: [Wei Gu, Pinar Alper, Kees van Bochove]
 description: Ensure high quality research data
 page_id: data quality
+redirect_from: /pid/data quality
 related_pages: 
     tool_assembly: []
 dsw:

--- a/pages/your_tasks/data_transfer.md
+++ b/pages/your_tasks/data_transfer.md
@@ -3,6 +3,7 @@ title: Data transfer
 contributors: [Olivier Collin, Alan R Williams, Flora D'Anna, Frederik Delaere, Munazah Andrabi] 
 description: How to transfer data files
 page_id: transfer
+redirect_from: /pid/transfer
 related_pages: 
     tool_assembly: []
 training:

--- a/pages/your_tasks/dm_coordination.md
+++ b/pages/your_tasks/dm_coordination.md
@@ -3,6 +3,7 @@ title: Project data management coordination
 description: how to coordinate and organise data management activities in collaborative or multi-parter projects
 contributors: [Robert Andrews, Stefanie Meyer, Tereza Motalova, Graham Parton, Marko Petek, Maja Zagorščak, Karolina Zavoralova, Karel Berka, Korbinian Bösl, Flora D'Anna, Niclas Jareborg, Yvonne Kallberg, Paulette Lieby]
 page_id: DM coordination
+redirect_from: /pid/DM coordination
 related_pages: 
   tool_assembly: []
 training:

--- a/pages/your_tasks/existing_data.md
+++ b/pages/your_tasks/existing_data.md
@@ -2,6 +2,7 @@
 title: Existing data
 contributors: [Rob Hooft, Flora D'Anna, Pinar Alper, Yvonne Kallberg, Karel Berka, Marko Vidak, Olivier Collin, Ulrike Wittig]
 page_id: existing data
+redirect_from: /pid/existing data
 related_pages:
     tool_assembly: []
 description: How to find and reuse existing data

--- a/pages/your_tasks/identifiers.md
+++ b/pages/your_tasks/identifiers.md
@@ -3,6 +3,7 @@ title: Identifiers
 contributors: [Markus Englund, Flavio Licciulli, Nick Juty, Olivier Collin, Ulrike Wittig, Ivan Mičetić, Karel Berka, Shuxin Zhang, Hinri Kerstens, Flora D'Anna, Yvonne Kallberg, Rob Hooft] 
 description: How to use identifiers for research data
 page_id: identifiers
+redirect_from: /pid/identifiers
 related_pages: 
     tool_assembly: []
 dsw:

--- a/pages/your_tasks/licensing.md
+++ b/pages/your_tasks/licensing.md
@@ -3,6 +3,7 @@ title: Licensing
 contributors: [Siiri Fuchs, Minna Ahokas, Nicola Soranzo, Rob Hooft]
 description: How to license research data
 page_id: licensing
+redirect_from: /pid/licensing
 related_pages: 
   tool_assembly: []
 dsw:

--- a/pages/your_tasks/machine_actionability.md
+++ b/pages/your_tasks/machine_actionability.md
@@ -3,6 +3,7 @@ title: Machine actionability
 contributors: [Karel Berka, Flora D'Anna, Erik Hjerde, Yvonne Kallberg, Sirarat Sarntivijai, Nazeefa Fatima, Rafael Andrade Buono, Alex Henderson, Korbinian Bösl, Dominik Martinat, M-Christine Jacquemot-Perbal]
 description: How to make machine-actionable (meta)data
 page_id: machine actionability
+redirect_from: /pid/machine actionability
 related_pages: 
     tool_assembly: []
 dsw:

--- a/pages/your_tasks/metadata_management.md
+++ b/pages/your_tasks/metadata_management.md
@@ -3,6 +3,7 @@ title: Documentation and metadata
 contributors: [Flora D'Anna, Marco Carraro, Yvonne Kallberg, Markus Englund, Marco Roos, Korbinian Bösl, Rob Hooft]
 description: How to document and describe your data
 page_id: metadata
+redirect_from: /pid/metadata
 related_pages:
   tool_assembly: [NeLS, transmed, plant geno assembly, marine assembly]
 dsw:

--- a/pages/your_tasks/sensitive_data.md
+++ b/pages/your_tasks/sensitive_data.md
@@ -3,6 +3,7 @@ title: Sensitive data
 contributors: [Rob Hooft, Yvonne Kallberg, Pinar Alper, Markus Englund, Thanasis Vergoulis, Robert Andrews]
 description: How to identify different research data types
 page_id: sensitive
+redirect_from: /pid/sensitive
 related_pages: 
   tool_assembly: [TSD, Covid-19, transmed]
 training:

--- a/pages/your_tasks/storage.md
+++ b/pages/your_tasks/storage.md
@@ -3,6 +3,7 @@ title: Data storage
 contributors: [Ulrike Wittig, Elin Kronander, Munazah Andrabi, Flora D'Anna, Flavio Licciulli, Ott Oopkaup, Marcus Lundberg, Thanasis Vergoulis, Frederik Coppens, Olivier Collin, Nadia Tonello, Korbinian Bösl]
 description: How to find appropriate storage solutions
 page_id: storage
+redirect_from: /pid/storage
 related_pages: 
   tool_assembly: [NeLS, TSD, ome, transmed, XNAT-PIC]
 training:


### PR DESCRIPTION
This is a proof of concept to have persistent identifiers on RDMkit, this will close #818 

In this scenario we use the `redirect_from` attribute on every page to serve the page at `https://rdmkit.elixir-europe.org/pid/page_id` 

On the w3id side we redirect from `https://w3id.org/rdmkit/page_id` to https://rdmkit.elixir-europe.org/pid/page_id, which wil redirect to https://rdmkit.elixir-europe.org/the correct page.


A discussion we will need to have is: what type of page identifiers are we going to use? 
In theory we want numerical ones that do not contain info related to the page, so it is content independent. But this will be difficult to use in "related pages", since one will have to use a mapping table all the time to fill them in.... 

If we keep on using text-identifiers , we have to get rid of our spaces! 

