### PR TITLE
Add supported registries for training attribute

### DIFF
--- a/pages/contribute/page_metadata.md
+++ b/pages/contribute/page_metadata.md
@@ -73,10 +73,12 @@ title: Title of the page
       url: example_url
   ```
 
+The supported registries that can be used in the `registries` attribute are: *YouTube*, *Zenodo*, *Carpentries* and *TeSS*.
+
 * `faircookbook`: Here all relevant FAIR Cookbook recipes are listed. This is automaticity updated based on the [`faircookbook_rdmkit_mapping.yml`](https://github.com/elixir-europe/faircookbook-rdmkit/blob/main/faircookbook_rdmkit_mapping.yml) mapping file. If you want to make a new link, please make a pull request against this file. Every week the changes of this mapping file are used to update the frontmatter of the corresponding markdown files.
 
 
-* `dsw`: Here all relevant Data Stewardship Wizard questions in the RDMkit knowledge model are listed. This is automaticity updated and can not be altered by humans! If you want to add a link you have to add the link towards the RDMkit page the the knowledge model on DSW.
+* `dsw`: Here all relevant Data Stewardship Wizard questions in the Researcher knowledge model are listed. This is automaticity updated and can not be altered by humans! If you want to add a link you have to add the link towards the RDMkit page the the knowledge model on DSW.
 
 
 

--- a/pages/contribute/page_metadata.md
+++ b/pages/contribute/page_metadata.md
@@ -73,7 +73,7 @@ title: Title of the page
       url: example_url
   ```
 
-  The supported registries that can be used in the `registries` attribute are: *YouTube*, *Zenodo*, *Carpentries* and *TeSS*.
+  The supported registries that can be used in the `registry` attribute are: *YouTube*, *Zenodo*, *Carpentries* and *TeSS*.
 
 * `faircookbook`: Here all relevant FAIR Cookbook recipes are listed. This is automaticity updated based on the [`faircookbook_rdmkit_mapping.yml`](https://github.com/elixir-europe/faircookbook-rdmkit/blob/main/faircookbook_rdmkit_mapping.yml) mapping file. If you want to make a new link, please make a pull request against this file. Every week the changes of this mapping file are used to update the frontmatter of the corresponding markdown files.
 

--- a/pages/contribute/page_metadata.md
+++ b/pages/contribute/page_metadata.md
@@ -73,7 +73,7 @@ title: Title of the page
       url: example_url
   ```
 
-The supported registries that can be used in the `registries` attribute are: *YouTube*, *Zenodo*, *Carpentries* and *TeSS*.
+  The supported registries that can be used in the `registries` attribute are: *YouTube*, *Zenodo*, *Carpentries* and *TeSS*.
 
 * `faircookbook`: Here all relevant FAIR Cookbook recipes are listed. This is automaticity updated based on the [`faircookbook_rdmkit_mapping.yml`](https://github.com/elixir-europe/faircookbook-rdmkit/blob/main/faircookbook_rdmkit_mapping.yml) mapping file. If you want to make a new link, please make a pull request against this file. Every week the changes of this mapping file are used to update the frontmatter of the corresponding markdown files.
 

--- a/pages/data_life_cycle/TEMPLATE_rdm_cycle.md
+++ b/pages/data_life_cycle/TEMPLATE_rdm_cycle.md
@@ -10,6 +10,7 @@ training:
   - name:
     registry:
     url:
+# More information on how to fill in this metadata section can be found here https://rdmkit.elixir-europe.org/page_metadata
 ---
 
 ## What is "data + stage name"? <!-- edit this heading (e.g. what is data analysis?) and write your text below it -->

--- a/pages/national_resources/TEMPLATE_resources.md
+++ b/pages/national_resources/TEMPLATE_resources.md
@@ -44,6 +44,7 @@ national_resources:
       biotools: <!--- DELETE ME if not needed --->
       fairsharing: <!--- DELETE ME if not needed --->
       tess: <!--- DELETE ME if not needed --->
+# More information on how to fill in this metadata section can be found here https://rdmkit.elixir-europe.org/page_metadata
 ---
 <!---All the resources added above will appear on the table at the bottom of the page--->
 

--- a/pages/tool_assembly/TEMPLATE_tool_assembly.md
+++ b/pages/tool_assembly/TEMPLATE_tool_assembly.md
@@ -12,6 +12,8 @@ training:
   - name:
     registry:
     url:
+# More information on how to fill in this metadata section can be found here https://rdmkit.elixir-europe.org/page_metadata
+
 ---
 
 <!--- Tool Assembly pages should detail a particular data management tool assembly which covers one more life cycle stages from an infrastructural or domain perspective. For an example for an infrastructural example, please see: https://github.com/elixir-europe/rdmkit/blob/master/pages/tool_assembly/nels_assembly.md 

--- a/pages/your_domain/TEMPLATE_your_domain.md
+++ b/pages/your_domain/TEMPLATE_your_domain.md
@@ -11,6 +11,7 @@ training:
   - name:
     registry:
     url:
+# More information on how to fill in this metadata section can be found here https://rdmkit.elixir-europe.org/page_metadata
 ---
 
 <!--- Domain pages should detail the particular data management challenges of the domain, typically by complementing and extending one or more existing Problem pages.

--- a/pages/your_role/TEMPLATE_your_role.md
+++ b/pages/your_role/TEMPLATE_your_role.md
@@ -10,6 +10,7 @@ training:
   - name:
     registry:
     url:
+# More information on how to fill in this metadata section can be found here https://rdmkit.elixir-europe.org/page_metadata
 ---
 
 {% include callout.html type="note" content="This page is under construction." %}

--- a/pages/your_tasks/TEMPLATE_your_tasks.md
+++ b/pages/your_tasks/TEMPLATE_your_tasks.md
@@ -10,6 +10,7 @@ training:
   - name:
     registry:
     url:
+# More information on how to fill in this metadata section can be found here https://rdmkit.elixir-europe.org/page_metadata
 ---
 
 ## Concrete problem 1, formulated as a question <!-- example: what is the best way to name a file?-->


### PR DESCRIPTION
  The supported registries that can be used in the `registry` attribute are: *YouTube*, *Zenodo*, *Carpentries* and *TeSS*.
  
  and linking out to the metadata manual in the metadata section itself 