### PR TITLE
Update to templates

### DIFF
--- a/pages/data_life_cycle/TEMPLATE_rdm_cycle.md
+++ b/pages/data_life_cycle/TEMPLATE_rdm_cycle.md
@@ -3,9 +3,10 @@ title: -ing form of the stage name - (e.g. analysing, rather than just analyse)
 contributors: [<!---REPLACE THIS with comma separated list of contributors--->]
 search_exclude: true
 description: <!---REPLACE THIS with a one sentence description of the page--->
-page_id: <!---REPLACE THIS with a shortened page name, with small letters and spaces, or an acronym in capital and small letters--->
+page_id: <!---REPLACE THIS with a shortened page name (including acronym), with small letters (lowercase) and underscore(s)--->
 related_pages: 
   your_tasks: [<!---REPLACE THIS with the page ID of the your_tasks pages that you want to list here as related pages--->]
+# More information on which page id you can use can be found at https://rdmkit.elixir-europe.org/website_overview
 training:
   - name:
     registry:

--- a/pages/data_life_cycle/TEMPLATE_rdm_cycle.md
+++ b/pages/data_life_cycle/TEMPLATE_rdm_cycle.md
@@ -22,4 +22,4 @@ Short explanation of why people should do / be aware of this stage. Advantages a
 
 ## What should be considered for "data + stage name"? <!-- edit this heading (e.g. what should be considered for data analysis?) and write your text below it -->
 List and explain all aspects that need to be taken into account to manage this "stage" according to best practices and FAIR principles.
-* Bullet point considerations
+* [Bullet point](style_guide#text) considerations

--- a/pages/data_life_cycle/TEMPLATE_rdm_cycle.md
+++ b/pages/data_life_cycle/TEMPLATE_rdm_cycle.md
@@ -3,7 +3,7 @@ title: -ing form of the stage name - (e.g. analysing, rather than just analyse)
 contributors: [<!---REPLACE THIS with comma separated list of contributors--->]
 search_exclude: true
 description: <!---REPLACE THIS with a one sentence description of the page--->
-page_id: <!---REPLACE THIS with a shortened page name (including acronym), with small letters (lowercase) and underscore(s)--->
+page_id: <!---REPLACE THIS with a shortened page name. The shortened page name should be in lowercase and separated by underscore(s) if needed. For example, page_id of structural bioinformatics will be struct_bioinfo
 related_pages: 
   your_tasks: [<!---REPLACE THIS with the page ID of the your_tasks pages that you want to list here as related pages--->]
 # More information on which page id you can use can be found at https://rdmkit.elixir-europe.org/website_overview

--- a/pages/national_resources/TEMPLATE_resources.md
+++ b/pages/national_resources/TEMPLATE_resources.md
@@ -6,7 +6,8 @@ country_code: <!---REPLACE THIS with the ISO 3166-1-alpha-2 country code, capita
 contributors: [<!---REPLACE THIS with comma separated list of contributors--->]
 coordinators: [<!---REPLACE THIS with the name of data management coordinators of your ELIXIR node--->]
 
-# Link to other pages in the tool assembly section on the RDMkit by listing the page_id 
+# Link to other pages in the tool assembly section on the RDMkit by listing the page_id.
+# More information on which page_id you can use can be found at https://rdmkit.elixir-europe.org/website_overview 
 related_pages:
   tool_assembly: [<!---REPLACE THIS with the page ID of the tool_assembly pages that you want to list here as related pages--->]
 

--- a/pages/tool_assembly/TEMPLATE_tool_assembly.md
+++ b/pages/tool_assembly/TEMPLATE_tool_assembly.md
@@ -4,10 +4,11 @@ search_exclude: true
 contributors: [<!---REPLACE THIS with comma separated list of contributors--->] 
 description: <!---REPLACE THIS with a very short summary (one sentence) this should include if there are limitiations for the audience--->
 affiliations: [<!---REPLACE THIS with comma separated list of affiliations. Countries use the ISO 3166-1-alpha-2 notation, other affiliations must be present in the affiliations.yaml in the _data directory in order to work--->]
-page_id: <!---REPLACE THIS with a shortened page name, with small letters and spaces, or an acronym in capital and small letters--->
+page_id: <!---REPLACE THIS with a shortened page name. The shortened page name should be in lowercase and separated by underscore(s) if needed. For example, page_id of structural bioinformatics will be struct_bioinfo
 related_pages: 
   your_tasks: [<!---REPLACE THIS with the page ID of the your_tasks pages that you want to list here as related pages--->]
   your_domain: [<!---REPLACE THIS with the page ID of the your_domain pages that you want to list here as related pages--->]
+# More information on which page id you can use can be found at https://rdmkit.elixir-europe.org/website_overview
 training:
   - name:
     registry:

--- a/pages/tool_assembly/TEMPLATE_tool_assembly.md
+++ b/pages/tool_assembly/TEMPLATE_tool_assembly.md
@@ -24,14 +24,14 @@ In the event that you describe a domain specific tool assembly and no adequate D
 
 <!--- In this section you should provide a brief overview of the tool assembly, mentioning and putting into context the challenges that are particularly solved by the tool assembly and define potential users  --->
 
+<!---If need be, you can create a separate section to organise information e.g. a section titled "Who can use the TOOL ASSEMBLY?" can be used to define potential users--->
 
-## section 1 title
- 
 ### What can you use the TOOL ASSEMBLY for?
 <!--- Sections within Tool Assembly pages (aside from "Introduction" at the start and "Relevant tools and resources " at the end) should be used to describe the potential usage of the tool and the tool assembly --->
 
+### How to access the TOOL ASSEMBLY?
 
-<!--- ## Section 2 Title --->
+<!--- ## Section Title --->
 <!--- Add more sections as needed. --->
 ...
 

--- a/pages/your_domain/TEMPLATE_your_domain.md
+++ b/pages/your_domain/TEMPLATE_your_domain.md
@@ -3,10 +3,11 @@ title: Domain page title
 search_exclude: true
 description: <!---REPLACE THIS with a one sentence description of the page--->
 contributors: [<!---REPLACE THIS with comma separated list of contributors--->]
-page_id: <!---REPLACE THIS with a shortened page name, with small letters and spaces, or an acronym in capital and small letters--->
+page_id: <!---REPLACE THIS with a shortened page name. The shortened page name should be in lowercase and separated by underscore(s) if needed. For example, page_id of structural bioinformatics will be struct_bioinfo
 related_pages: 
   your_tasks: [<!---REPLACE THIS with the page ID of the your_tasks pages that you want to list here as related pages--->]
   tool_assembly: [<!---REPLACE THIS with the page ID of the tool_assembly pages that you want to list here as related pages--->]
+# More information on which page id you can use can be found at https://rdmkit.elixir-europe.org/website_overview
 training:
   - name:
     registry:

--- a/pages/your_role/TEMPLATE_your_role.md
+++ b/pages/your_role/TEMPLATE_your_role.md
@@ -3,9 +3,10 @@ title: <Your persona>
 search_exclude: true
 description: <!---REPLACE THIS with a one sentence description of the page--->
 contributors: [<!---REPLACE THIS with comma separated list of contributors--->]
-page_id: <!---REPLACE THIS with a shortened page name, with small letters and spaces, or an acronym in capital and small letters--->
+page_id: <!---REPLACE THIS with a shortened page name. The shortened page name should be in lowercase and separated by underscore(s) if needed. For example, page_id of structural bioinformatics will be struct_bioinfo
 related_pages: 
   your_tasks: [<!---REPLACE THIS with the page ID of the your_tasks pages that you want to list here as related pages--->]
+# More information on which page id you can use can be found at https://rdmkit.elixir-europe.org/website_overview
 training:
   - name:
     registry:

--- a/pages/your_tasks/TEMPLATE_your_tasks.md
+++ b/pages/your_tasks/TEMPLATE_your_tasks.md
@@ -22,11 +22,11 @@ Short explanation of what this problem is about.
 
 ### Considerations <!-- do not delete this heading and write your text below it -->
 
-* Structured in bullet points as much as possible, detailing things to consider about this problem in order to be able to find the right solution.
+* [Structured in bullet points](style_guide#text) as much as possible, detailing things to consider about this problem in order to be able to find the right solution.
 
 ### Solutions <!-- do not delete this heading and write your text below it -->
 
-By using bullet point style as much as possible, try to describe when, why and for what is best to use a specific tool or resource. 
+By using [bullet point style](style_guide#text) as much as possible, try to describe when, why and for what is best to use a specific tool or resource. 
 Avoid making long list of links to tools and resources.
 Make sure to add the tools and resources mentioned in the text in the main "tools and resources" table.
 

--- a/pages/your_tasks/TEMPLATE_your_tasks.md
+++ b/pages/your_tasks/TEMPLATE_your_tasks.md
@@ -3,9 +3,10 @@ title: Global problem title (e.g. metadata management)
 search_exclude: true
 description: <!---REPLACE THIS with a one sentence description of the page--->
 contributors: [<!---REPLACE THIS with comma separated list of contributors--->]
-page_id: <!---REPLACE THIS with a shortened page name, with small letters and spaces, or an acronym in capital and small letters--->
+page_id: <!---REPLACE THIS with a shortened page name. The shortened page name should be in lowercase and separated by underscore(s) if needed. For example, page_id of structural bioinformatics will be struct_bioinfo --->
 related_pages: 
   tool_assembly: [<!---REPLACE THIS with the page ID of the tool_assembly pages that you want to list here as related pages--->]
+# More information on which page id you can use can be found at https://rdmkit.elixir-europe.org/website_overview
 training:
   - name:
     registry:


### PR DESCRIPTION
We have updated template markdown documents for all six sections with following text:
> page_id: <!---REPLACE THIS with a shortened page name. The shortened page name should be in lowercase and separated by underscore(s) if needed. For example, page_id of structural bioinformatics will be struct_bioinfo --->
.
.
.
> #More information on which page id you can use can be found at https://rdmkit.elixir-europe.org/website_overview
