### PR TITLE
Add ETT branding in footer of RDMkit + training fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@ _pdf
 .DS_Store
 .idea
 .bundle/
-_site
-/vendor
+_site/
+vendor/
 .vscode/
 Gemfile.lock

--- a/_config.yml
+++ b/_config.yml
@@ -4,7 +4,7 @@ title: RDMkit
 description: "Best practices and guidelines you can use for FAIR management of your research data."
 # Metadata description of the website
 
-remote_theme: ELIXIR-Belgium/elixir-toolkit-theme@new-branding
+remote_theme: ELIXIR-Belgium/elixir-toolkit-theme@1.22.0
 sass:
   style: compressed
   sourcemap: never

--- a/_config.yml
+++ b/_config.yml
@@ -4,8 +4,7 @@ title: RDMkit
 description: "Best practices and guidelines you can use for FAIR management of your research data."
 # Metadata description of the website
 
-remote_theme: ELIXIR-Belgium/elixir-toolkit-theme@1.21.0
-
+remote_theme: ELIXIR-Belgium/elixir-toolkit-theme@new-branding
 sass:
   style: compressed
   sourcemap: never

--- a/_config.yml
+++ b/_config.yml
@@ -4,7 +4,7 @@ title: RDMkit
 description: "Best practices and guidelines you can use for FAIR management of your research data."
 # Metadata description of the website
 
-remote_theme: ELIXIR-Belgium/elixir-toolkit-theme@1.22.0
+remote_theme: ELIXIR-Belgium/elixir-toolkit-theme@1.23.0
 sass:
   style: compressed
   sourcemap: never

--- a/index.html
+++ b/index.html
@@ -8,6 +8,7 @@ layout: none
 {% include head.html %}
 
 <body>
+    {% if jekyll.environment == "development" %}{% include dev-info.html %}{% endif %}
     {% include topnav.html search=false %}
     <div class="landingpage">
         <section class="container mb-5">

--- a/index.html
+++ b/index.html
@@ -159,7 +159,7 @@ layout: none
     </div>
     {%- if site.theme_variables.back_to_top or site.theme_variables.back_to_top == nil %}
     <button id="back-to-top" class="btn btn-primary" type="button" aria-hidden="true" onclick="topFunction()">
-        <i class="fa-solid fa-arrow-up"></i><span class="ms-2 d-none d-sm-inline">Back to top</span>
+        <i class="fa-solid fa-arrow-up"></i>
     </button>
     {%- endif %}
     {% include footer.html %}


### PR DESCRIPTION
This will close #1172 and bring the mention of the [ELIXIR Toolkit Theme](https://elixir-belgium.github.io/elixir-toolkit-theme) in the footer:

![Screenshot from 2023-01-26 10-05-14](https://user-images.githubusercontent.com/44875756/214815313-136cf17f-caff-48f1-b4e1-e72c2c87d67a.png)