### PR TITLE
Fixing broken link to the EC style guide

### DIFF
--- a/pages/contribute/style_guide.md
+++ b/pages/contribute/style_guide.md
@@ -2,7 +2,7 @@
 title: Style guide
 ---
 
-In general, we follow the European Commission's [Web Writing Style Guide](https://wikis.ec.europa.eu/display/WEBGUIDE/02.+Web+writing+guidelines) and the more detailed [English Style Guide](https://commission.europa.eu/system/files/2022-12/styleguide_english_dgt_en.pdf). Below are the points that you might find most useful, though, and that relate particularly to the RDMkit.
+In general, we follow the European Commission's [Web Writing Style Guide](https://wikis.ec.europa.eu/display/WEBGUIDE/02.+Web+writing+guidelines) and the more detailed [English Style Guide](https://commission.europa.eu/system/files/2023-01/styleguide_english_dgt_en.pdf). Below are the points that you might find most useful, though, and that relate particularly to the RDMkit.
 
 ## General style and tone
   * Keep the tone friendly rather than formal, and use "you". Imagine you were explaining something verbally to someone - how would you say it?


### PR DESCRIPTION
The link for this guide has changed a couple of times recently. [Yet another EC style guide](https://wikis.ec.europa.eu/download/attachments/6824833/commission_style_guide.pdf?version=1&modificationDate=1594633342434&api=v2) exists, but maybe we're okay with the two we recommend.