### PR TITLE
Link to all google doc  templates

### DIFF
--- a/pages/contribute/google_doc_way.md
+++ b/pages/contribute/google_doc_way.md
@@ -10,8 +10,12 @@ RDMkit is hosted on GitHub. We understand, however, that many people may be unfa
 The steps are as follows:
 * Email the editorial team at [rdm-editors@elixir-europe.org](mailto:rdm-editors@elixir-europe.org) to propose a new page or a new section in an existing page. Make sure you keep other contributors in the CC of your email. The editors will create an issue in our GitHub repository to announce your contribution to others.  
 * Use our section specifc google doc templates to write your page:
-*   [Your Domain Template](https://docs.google.com/document/d/1fh8-Gq50AkXS1nhHr-gVFog-eI61dFI49nKROZlRYEQ/edit?usp=sharing)
-* 
+    *  [Your task template](https://docs.google.com/document/d/11MsyGl7WJXI4dahMjbI3addEXQlpDzM19Yk_6e-gsVI)
+    *  [Your domain template](https://docs.google.com/document/d/1fh8-Gq50AkXS1nhHr-gVFog-eI61dFI49nKROZlRYEQ)
+    *  [Your role template](https://docs.google.com/document/d/1J8SmHw-TtVQ6P38SzucRB37upYwscUOwbTx_qllOPaI)
+    *  [Tools assembly template](https://docs.google.com/document/d/1BZsc647JAmJwUkVjds5cu52_-70_TTfDMypPHqDiFrM)
+    *  [National resources template](https://docs.google.com/document/d/1icB57BHMbZbxwFV9keq9ZYm5QbrDjJDeufrTdoYmHzk)
+
 * Notify the editorial team when you are finished.
 * The editors will assign reviewers to your page, who will provide feedback as comments on the shared google doc.
 * Address the reviewers' comments and let the editorial team know, again by mail, that you're finished with revisions.


### PR DESCRIPTION
With this PR we will finally have section specific google doc templates for all of them. I tried to let them all match with each other in terms of style. The content is the same as the markdown templates. This will close #1179 