### PR TITLE
Add definition of data in the data life cycle landing page

### DIFF
--- a/pages/data_life_cycle.md
+++ b/pages/data_life_cycle.md
@@ -2,6 +2,9 @@
 title: Data life cycle
 ---
 
+In the RDMkit, data can be defined as any information or materials that are collected, observed, generatared, or used during the research process. Data can take various forms, including experimental results, numerical data, text documents, images, software code, surveys, and more.
+
+The RDMkit recognises the importance of managing data effectively through the research lifecycle, and the need to handle data in a structured, organised, and documented manner to ensure its quality, integirty, and long-term usability.
 
 In this section, information is organised according to the stages of the research data life cycle. You will find:
 - A general description and introduction of each  stage.


### PR DESCRIPTION
Add definition of data in the data life cycle landing page. It can be moved to any other page if we think it is better, but I thought here was a good place to have it.