### PR TITLE
No RDMbites TeSS duplication

### DIFF
--- a/pages/your_domain/human_data.md
+++ b/pages/your_domain/human_data.md
@@ -10,9 +10,6 @@ training:
   - name: Training in TeSS
     registry: TeSS
     url: https://tess.elixir-europe.org/search?q=sensitive%20human%20data
-  - name: RDMbites about data sensitivity
-    registry: TeSS
-    url: https://tess.elixir-europe.org/collections/rdmbites-sensitive-data-collection
   - name: A FAIR guide for data providers to maximise sharing of human genomic data
     url: https://journals.plos.org/ploscompbiol/article?id=10.1371/journal.pcbi.1005873
   - name: Toward better governance of human genomic data

--- a/pages/your_tasks/sensitive_data.md
+++ b/pages/your_tasks/sensitive_data.md
@@ -9,12 +9,7 @@ training:
   - name: Training in TeSS
     registry: TeSS
     url: https://tess.elixir-europe.org/search?q=%22sensitive+data%22#materials
-  - name: RDMbites for using REDCap
-    registry: TeSS
-    url: https://tess.elixir-europe.org/collections/rdmbites-redcap-collection
-  - name: RDMbites about data sensitivity
-    registry: TeSS
-    url: https://tess.elixir-europe.org/collections/rdmbites-sensitive-data-collection
+
 dsw:
 - name: Are there privacy reasons why your data can not be open?
   uuid: 019db0b3-9067-4134-8bfd-76db3cfc572a


### PR DESCRIPTION
As we discussed a very long time ago, we would only take away the RDMbites mentions if the TeSS link does lead to them. 

We are very close to this point besides the human data page having a RDMbites collection that does net yet have the "sensitive human data" tag. When this is done we can close #1181 