### PR TITLE
CONVERGE mentions need to be updated

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ The process documents and data are made available under a CC-BY license. Softwar
 
 ## Acknowledgements
 
-The RDMkit was supported by [ELIXIR-CONVERGE](https://elixir-europe.org/about-us/how-funded/eu-projects/converge) and it is coordinated by [ELIXIR Europe](https://elixir-europe.org/).
+The RDMkit was supported by [ELIXIR-CONVERGE](https://elixir-europe.org/about-us/how-funded/eu-projects/converge) and it is coordinated by [ELIXIR Europe](https://elixir-europe.org/) and [NIH](https://www.nih.gov/).
 
 <br>
 <br>

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Do you which to contact the editors of this project? Use [rdm-editors@elixir-eur
 If you want to build the website locally, please have a look at our [tutorial](working_with_git#the-advantage-of-working-locally-previewing-your-changes-through-your-web-browser).
 
 
-## RDMkit is an ELIXIR Converge project
+## RDMkit is an ELIXIR product
 
 ELIXIR is an intergovernmental organisation that brings together life science resources from across Europe. These resources include databases, software tools, training materials, cloud storage and supercomputers. All the ELIXIR National nodes and the special EMBL-EBI node have come to support data management within the Nodes and for data stewards, researchers and institutional data managers. The idea is to support data management at the point of creation and enable data to be "FAIR by Design". The development of a Research Data Management Kit will provide researchers with a strategy to manage their data to international standards. 
 
@@ -40,9 +40,7 @@ The process documents and data are made available under a CC-BY license. Softwar
 
 ## Acknowledgements
 
-The RDMkit is supported by:
-- ELIXIR-CONVERGE https://elixir-europe.org/about-us/how-funded/eu-projects/converge
-- Contributions from the 23 ELIXIR Nodes
+The RDMkit was supported by [ELIXIR-CONVERGE](https://elixir-europe.org/about-us/how-funded/eu-projects/converge).
 
 <br>
 <br>

--- a/_data/footer.yml
+++ b/_data/footer.yml
@@ -1,4 +1,4 @@
-copyright: '[![Creative Commons License](https://i.creativecommons.org/l/by/4.0/88x31.png)](http://creativecommons.org/licenses/by/4.0/) RDMkit by [ELIXIR-CONVERGE](https://elixir-europe.org/about-us/how-funded/eu-projects/converge) is licensed under a [Creative Commons Attribution 4.0 International License](http://creativecommons.org/licenses/by/4.0/), except where otherwise noted.'
+copyright: '[![Creative Commons License](https://i.creativecommons.org/l/by/4.0/88x31.png)](http://creativecommons.org/licenses/by/4.0/) RDMkit by [ELIXIR](https://elixir-europe.org/) is licensed under a [Creative Commons Attribution 4.0 International License](http://creativecommons.org/licenses/by/4.0/), except where otherwise noted.'
 extra_line: Recommended in the <a href="https://ec.europa.eu/info/funding-tenders/opportunities/docs/2021-2027/horizon/guidance/programme-guide_horizon_en.pdf">Horizon Europe Program Guide</a> as the "resource for Data Management guidelines and good practices for the Life Sciences"
 columns:
   - type: image
@@ -12,12 +12,9 @@ columns:
       - url_text: Contributors
         url: /contributors
         external_url: 
-      - url_text: ELIXIR-CONVERGE
+      - url_text: ELIXIR
         url: 
-        external_url: https://elixir-europe.org/about-us/how-funded/eu-projects/converge
-      - url_text: Contributions from the 23 ELIXIR Nodes
-        url: 
-        external_url: 
+        external_url: https://elixir-europe.org
       - url_text: Institutes, projects and funders
         url: /support
         external_url: 

--- a/pages/about/about.md
+++ b/pages/about/about.md
@@ -5,7 +5,7 @@ title: About
 ## Who is the RDMkit for?
 The ELIXIR Research Data Management Kit (RDMkit) has been designed to guide life scientists in their efforts to better manage their research data following the FAIR Principles. It is based on the various steps of the data lifecycle, although not all the steps will be relevant to everyone.
 
-The contents are generated and maintained by the ELIXIR community coming together as part of the [ELIXIR-CONVERGE](https://elixir-europe.org/about-us/how-funded/eu-projects/converge) project. More information on how we want to sustain and govern RDMkit can be found on the [RDMkit Alliance page](rdmkit_alliance).
+The contents are generated and maintained by the ELIXIR community. More information on how we want to sustain and govern RDMkit can be found on the [RDMkit Alliance page](rdmkit_alliance).
 
 <div class="card bg-light my-4">
   <div class="card-body">

--- a/pages/about/contact.md
+++ b/pages/about/contact.md
@@ -11,3 +11,8 @@ If you would like to contact the editorial team, please send an email to <rdm-ed
 If you encounter any technical issues with the RDMkit, please submit a bug report on our GitHub: <https://github.com/elixir-europe/rdmkit/issues>
 
 We will do our best to respond to your enquiry as soon as possible. 
+
+## Making a quick suggestion
+
+<iframe src="https://docs.google.com/forms/d/e/1FAIpQLSfw1hcOlXcgJ1mImx_37WLnA160SPObP8crEdkSRVEAX2AIrw/viewform?embedded=true" width="640" height="1000" frameborder="0" marginheight="0" marginwidth="0" style="width: 100%;" class="mt-1">Loading…</iframe>
+

--- a/pages/about/support.md
+++ b/pages/about/support.md
@@ -17,7 +17,7 @@ We thank these projects for their efforts:
 
 ## Funders
 
-RDMkit is developed in ELIXIR-CONVERGE that received funding from the European Union's Horizon 2020 Research and Innovation programme under grant agreement No 871075. 
+Development of RDMkit was initiated in ELIXIR-CONVERGE that received funding from the European Union's Horizon 2020 Research and Innovation programme under grant agreement No 871075. 
 
 Additionally we thank the funders that supported some of our contributors.
 


### PR DESCRIPTION
CONVERGE is over, and the about pages/acknowledgements need to be updated accordingly.

To be discussed in the RDMkit Club meeting:
- Do we still keep the CONVERGE logo in the footer? 
- We need a oneliner how RDMkit is funded for the README page
- We need a governance statement for the about

This will close #1372 