### PR TITLE
Correct link to the EC style guide

### DIFF
--- a/pages/contribute/style_guide.md
+++ b/pages/contribute/style_guide.md
@@ -2,7 +2,7 @@
 title: Style guide
 ---
 
-In general, we follow the European Commission's [Web Writing Style Guide](https://wikis.ec.europa.eu/display/WEBGUIDE/02.+Web+writing+guidelines) and the more detailed [English Style Guide](https://commission.europa.eu/system/files/2023-01/styleguide_english_dgt_en.pdf). Below are the points that you might find most useful, though, and that relate particularly to the RDMkit.
+In general, we follow the European Commission's [Web Writing Style Guide](https://wikis.ec.europa.eu/display/WEBGUIDE/02.+Web+writing+guidelines) and the more detailed [English Style Guide](https://commission.europa.eu/system/files/2023-07/styleguide_english_dgt_en.pdf). Below are the points that you might find most useful, though, and that relate particularly to the RDMkit.
 
 ## General style and tone
   * Keep the tone friendly rather than formal, and use "you". Imagine you were explaining something verbally to someone - how would you say it?


### PR DESCRIPTION
I've just realised: this link changes periodically since the url contains a date, and the style guide gets updated from time to time and the date changes. The old url stops working. This PR is a quick fix (a link to the latest version) but we probably have to find a more permanent solution.

Closes #1384