### PR TITLE
Update style_guide.md

### DIFF
--- a/pages/contribute/style_guide.md
+++ b/pages/contribute/style_guide.md
@@ -2,7 +2,7 @@
 title: Style guide
 ---
 
-In general, we follow the European Commission's [Web Writing Style Guide](https://wikis.ec.europa.eu/display/WEBGUIDE/02.+Web+writing+guidelines) and the more detailed [English Style Guide](https://commission.europa.eu/system/files/2023-07/styleguide_english_dgt_en.pdf). Below are the points that you might find most useful, though, and that relate particularly to the RDMkit.
+In general, we follow the European Commission's [Web Writing Style Guide](https://wikis.ec.europa.eu/display/WEBGUIDE/02.+Web+writing+guidelines) and their more detailed English Style Guide. Search online for "EC English style guide" to find the link, since it changes regularly. Below are the points that you might find most useful, though, and that relate particularly to the RDMkit. 
 
 ## General style and tone
   * Keep the tone friendly rather than formal, and use "you". Imagine you were explaining something verbally to someone - how would you say it?


### PR DESCRIPTION
I haven't been able to find a page on the EC site that links to the EC Style Guide. I was hoping to link to such a page, and rely on the EC to keep updating the link. Instead I have asked people to search for it. This is inconvenient, but the alternative is to leave out the style guide altogether. This would be a shame because it's the most detailed and therefore most useful guide. I think it's better to mention it.

Closes #1384 