### PR TITLE
update faircookbook links for plants

### DIFF
--- a/pages/tool_assembly/plant_genomics_assembly.md
+++ b/pages/tool_assembly/plant_genomics_assembly.md
@@ -9,7 +9,7 @@ related_pages:
   your_domain: [plants]
   tool_assembly: [plant_pheno_assembly]
 faircookbook:
-- name: Improving dataset maturity - the MIAPPE use case
+- name: MIAPPE-compliant submission to EMBL-EBI databases
   url: https://w3id.org/faircookbook/FCB061
 ---
 

--- a/pages/tool_assembly/plant_phenomics_assembly.md
+++ b/pages/tool_assembly/plant_phenomics_assembly.md
@@ -21,6 +21,9 @@ training:
   - name: PHIS developer documentation
     registry:
     url: https://opensilex.github.io/docs-community-dev/
+faircookbook:
+- name: Publishing plant phenotypic data
+  url: https://w3id.org/faircookbook/FCB083
 ---
 
 ## What is the plant phenomics tool assembly and who can use it?

--- a/pages/your_domain/plant_sciences.md
+++ b/pages/your_domain/plant_sciences.md
@@ -12,8 +12,10 @@ training:
     registry: TeSS
     url: https://tess.elixir-europe.org/search?q=plant%20data%20management
 faircookbook:
-- name: Improving dataset maturity - the MIAPPE use case
+- name: MIAPPE-compliant submission to EMBL-EBI databases
   url: https://w3id.org/faircookbook/FCB061
+- name: Publishing plant phenotypic data
+  url: https://w3id.org/faircookbook/FCB083
 ---
 
 ## Introduction


### PR DESCRIPTION
Update FAIR Cookbook links for plants related pages.
To be merged after https://github.com/FAIRplus/the-fair-cookbook/pull/606 is merged.