### PR TITLE
Update nels_assembly.md

### DIFF
--- a/pages/tool_assembly/nels_assembly.md
+++ b/pages/tool_assembly/nels_assembly.md
@@ -10,7 +10,7 @@ related_pages:
 training:
   - name: Training in TeSS
     registry: TeSS
-    url: https://tess.elixir-europe.org/search?q=norway
+    url: https://tess.elixir-europe.org/search?q=NeLS+Norway
 ---
 
 ## What is the NeLS data management tool assembly?


### PR DESCRIPTION
Using a country keyword for a tool assembly might create undesired results when courses for other independent national resources/tools are registered into TeSS. 

With the current suggestion some results of the query get lost, but maybe the annotations on TeSS should be improved (e.g. including explicitly NeLS as a keyword or similar).