### PR TITLE
Adding metadata standards to the table of tools and resources

### DIFF
--- a/_data/tool_and_resource_list.yml
+++ b/_data/tool_and_resource_list.yml
@@ -2489,3 +2489,17 @@
     fairsharing: g7t2hv
     tess: Sequence Read Archive
   url: https://www.ncbi.nlm.nih.gov/sra
+- description: Minimum Information about a high-throughput SEQuencing Experiment
+  id: minseqe
+  name: MINSEQE
+  registry:
+    fairsharing: a55z32
+    tess: MINSEQE
+  url: https://doi.org/10.5281/zenodo.5706412
+- description: Minimum Information About a Microarray Experiment
+  id: miame
+  name: MIAME
+  registry:
+    fairsharing: 32b10v
+    tess: MIAME
+  url: https://www.fged.org/projects/miame/

--- a/pages/your_tasks/metadata_management.md
+++ b/pages/your_tasks/metadata_management.md
@@ -116,7 +116,7 @@ There are multiple standards for different types of data, ranging from generic d
   * On the repository website, go through the submission process (try to submit some dummy data) to identify metadata requirements. For instance, if you consider publishing your transcriptomic data in ArrayExpress, you can make your metadata spreadsheet by using [Annotare 2.0 submission tool](https://www.ebi.ac.uk/fg/annotare/), at the beginning of the project.
   * Be aware that data type specific repositories usually have check-lists for metadata. For example, the European Nucleotide Archive provides [sample checklists](https://www.ebi.ac.uk/ena/browser/checklists) that can also be downloaded as a spreadsheet after log in.
 
-* If you do not know yet what repository you will use, look for what is the recommended minimal information (i.e. “Minimum Information ...your topic”, e.g. [MIAME](https://www.fged.org/projects/miame) or [MINSEQE](https://www.fged.org/projects/minseqe) or {% tool "miappe" %}) required for your type of data in your community, or other metadata, at the following resources:
+* If you do not know yet what repository you will use, look for what is the recommended minimal information (i.e. “Minimum Information about your topic”, e.g. {%tool "miame" %}, {%tool "minseqe" %}, or {% tool "miappe" %}) required for your type of data in your community, or other metadata, at the following resources:
   * {% tool "rda-standards" %}
   * {% tool "fairsharing" %} at “Standards” and “Collections”
   * {% tool "data-curation-centre-metadata-list" %}


### PR DESCRIPTION
As discussed with @korbinib, adding MINSEQE and MIAME to the tool's table for consistency with MIAPPE which was in the table already. This also adds DOIs from FAIRsharing and training material from TeSS (RDMbites).

@korbinib For MINSEQE, I am using the Zenodo entry instead of the FGED page. This (a) matches the homepage indicated by the curator on FAIRsharing and (b) is stable (I remember we had issues with FGED pages in the past).

