### PR TITLE
Fix page id Covid-19 data portal page

### DIFF
--- a/pages/national_resources/ch_resources.md
+++ b/pages/national_resources/ch_resources.md
@@ -92,7 +92,7 @@ national_resources:
     how_to_access:
     instance_of:
     related_pages:
-      tool_assembly: [covid-19]
+      tool_assembly: [covid19_data_portal]
       your_domain: []
       your_role: []
       your_tasks: [existing_data]

--- a/pages/national_resources/lu_resources.md
+++ b/pages/national_resources/lu_resources.md
@@ -47,7 +47,7 @@ national_resources:
   - name: Luxembourg Covid-19 data portal
     description: The Luxembourgish COVID-19 Data Portal acts as a collection of links and provides information to support researchers to utilise Luxembourgish and European infrastructures for data sharing.  
     related_pages:
-      tool_assembly: [Covid-19]
+      tool_assembly: [covid19_data_portal]
       your_domain: [human data]
       your_tasks: [sensitive, existing data, data publication]
     url: https://covid19dataportal.lu/

--- a/pages/national_resources/no_resources.md
+++ b/pages/national_resources/no_resources.md
@@ -55,7 +55,7 @@ national_resources:
     related_pages:
       your_domain: [human_data]
       your_tasks: [sensitive, existing_data, data_publication]
-      tool_assembly: [covid-19_data_portal]
+      tool_assembly: [covid19_data_portal]
     url: https://covid19dataportal.no/
   - name: Federated EGA Norway node
     description: Federated instance collects metadata of -omics data collections stored in national or regional archives and makes them available for search through the main EGA portal. With this solution, sensitive data will not physically leave the country, but will reside on TSD.

--- a/pages/national_resources/se_resources.md
+++ b/pages/national_resources/se_resources.md
@@ -37,7 +37,7 @@ national_resources:
   - name: Swedish Pathogens Portal
     description: The Swedish Pathogens Portal provides information, guidelines, tools and services to support researchers to utilise Swedish and European infrastructures for data sharing.
     related_pages:
-      tool_assembly: [covid-19]
+      tool_assembly: [covid19_data_portal]
       your_domain: [human_data]
       your_tasks: [sensitive, existing_data, data_publication]
     url: https://pathogens.se/ 

--- a/pages/tool_assembly/covid19_data_portal.md
+++ b/pages/tool_assembly/covid19_data_portal.md
@@ -1,7 +1,7 @@
 ---
 title: COVID-19 Data Portal 
 contributors: [Guy Cochrane, Marianna Ventouratou, Nadim Rahman, Sam Holt]
-page_id: covid-19
+page_id: covid19_data_portal
 affiliations: [ELIXIR CONVERGE]
 related_pages:
   your_tasks: [sensitive, existing_data, data_publication, data_analysis]

--- a/pages/your_domain/human_data.md
+++ b/pages/your_domain/human_data.md
@@ -5,7 +5,7 @@ contributors: [Niclas Jareborg, Nirupama Benis, Ana Portugal Melo, Pinar Alper, 
 page_id: human_data
 related_pages:
   your_tasks: [sensitive, gdpr_compliance]
-  tool_assembly: [tsd, covid-19, transmed, fairtracks]
+  tool_assembly: [tsd, covid19_data_portal, transmed, fairtracks]
 training:
   - name: Training in TeSS
     registry: TeSS

--- a/pages/your_tasks/data_sensitivity.md
+++ b/pages/your_tasks/data_sensitivity.md
@@ -5,7 +5,7 @@ description: How to identify the sensitivity of different research data types
 page_id: sensitive
 redirect_from: sensitive_data
 related_pages: 
-  tool_assembly: [tsd, covid-19, transmed]
+  tool_assembly: [tsd, covid19_data_portal, transmed]
 training:
   - name: Training in TeSS
     registry: TeSS

--- a/pages/your_tasks/ethics.md
+++ b/pages/your_tasks/ethics.md
@@ -4,7 +4,7 @@ contributors: [Karel Berka , Erin Calhoun, Paulette Lieby, Anamika Chatterjee, K
 description: Working on aspects in the management of research data that can raise ethical issues
 page_id: ethics
 related_pages:
-  tool_assembly: [covid-19, transmed, tsd, csc]
+  tool_assembly: [covid19_data_portal, transmed, tsd, csc]
 training:
 - name: 'Learning material on ethics in RDM'
   registry: TeSS


### PR DESCRIPTION
The tools and resources on this page was not working due to the hyphen in the page id. I also took the opportunity to fix some mentions of this id + give it a more descriptive page id.