### PR TITLE
Remove national tool DMP Canvas Generator from general tool list

### DIFF
--- a/_data/tool_and_resource_list.yml
+++ b/_data/tool_and_resource_list.yml
@@ -672,10 +672,6 @@
     fairsharing: dt9z89
     tess: DisProt
   url: https://disprot.org/
-- description: Questionnaire, which generates a pre-filled a DMP
-  id: dmp-canvas-generator
-  name: DMP Canvas Generator
-  url: https://dmp.vital-it.ch
 - description: Semi-automatically generated, searchable catalogue of resources that are relevant to data management plans.
   id: dmplanner
   name: DMPlanner

--- a/pages/your_tasks/data_management_plan.md
+++ b/pages/your_tasks/data_management_plan.md
@@ -71,7 +71,6 @@ However, a number of web-based DMP tools are currently available that greatly fa
   * {% tool "argos" %}: the joint effort of OpenAIRE and EUDAT to deliver an open platform for Data Management Planning.
   * {% tool "data-stewardship-wizard" %}: publicly available open-source tool to collaboratively compose data management plans through smart and customisable questionnaires with FAIRness evaluation.
   * {% tool "damap" %}: tool for machine actionable Data Management Plans.
-  * {% tool "dmp-canvas-generator" %}: this tool, mainly for researchers in Switzerland, is based on a questionnaire following the structure of the SNSF (Swiss National Science Foundation) instructions for DMP submission. Each Swiss High School can develop a specific template/canvas.
   * {% tool "dmponline" %}: tool widely used in Europe and many universities or institutes provide a DMPonline instance to researchers.
   * {% tool "dmptool" %}: widely used tool and many universities or institutes provide a DMPTool instance to researchers.
   * {% tool "dmproadmap" %}: DMP Roadmap is a Data Management Planning tool. Management and development of DMP Roadmap is jointly provided by the Digital Curation Centre (DCC), http://www.dcc.ac.uk/, and the University of California Curation Center (UC3), http://www.cdlib.org/services/uc3/. The DMPTool and DMPonline sites are both now running from the joint DMPRoadmap codebase.


### PR DESCRIPTION
removed DMP Canvas Generator (since it is already a national tool). Hopefully, I did it right