### PR TITLE
Add ICTV ontology to the Virology domain page 

### DIFF
--- a/_data/tool_and_resource_list.yml
+++ b/_data/tool_and_resource_list.yml
@@ -3571,3 +3571,9 @@
   url: https://www.rohub.org/
   registry:
     fairsharing: d3c5fd
+- description: ICTV Ontology provides a machine-readable representation of the official International Committee on Taxonomy of Viruses taxonomy, supporting consistent annotation of virus metadata and improved interoperability across virology resources.
+  id: ictv-ontology
+  name: ICTV Ontology
+  registry:
+    fairsharing: a2e727
+  url: https://www.ebi.ac.uk/ols4/ontologies/ictv

--- a/pages/your_domain/virology.md
+++ b/pages/your_domain/virology.md
@@ -46,6 +46,7 @@ To effectively manage data heterogeneity in virology outbreak surveillance, seve
   * Integrate epidemiological and genomic data for outbreak analysis, by utilising phylodynamic workflows (e.g. BEAST, {% tool "nextstrain" %}, or TreeTime), enabling real-time outbreak tracking.
   * Implement structured pipelines for linking viral genome sequences with patient and outbreak metadata.
 * Apply domain-specific vocabularies for consistent annotation
+  * Use the {% tool "ictv-ontology" %} for consistent virus taxonomic annotation. It provides a machine-readable representation of the official ICTV taxonomy, supporting interoperable metadata and cross-resource integration.
   * Utilise the {% tool "evora-ontology" %} and {% tool "ictv" %} to ensure that virus-related metadata terms are standardised and interoperable.
   * Monitor updates in virology-specific ontologies to maintain alignment with evolving standards.
 By implementing these best practices, outbreak surveillance data can be better structured, more interoperable, and more effectively shared, ultimately improving global response efforts to viral outbreaks.


### PR DESCRIPTION
Adds the ICTV Ontology to the Virology domain page and the Tools and Resources list.

The ICTV Ontology represents the official ICTV virus taxonomy in a machine-readable form and supports consistent annotation and interoperability in virology data and metadata.

- added a short text on the Virology domain page recommending the ICTV Ontology
- added the ICTV Ontology to the tools and resources list
- included links to OLS and FAIRsharing
