### PR TITLE
Align RDMkit styling and dependencies with ELIXIR Toolkit theme main

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,21 +1,20 @@
-source 'https://rubygems.org'
+source "https://rubygems.org"
 
-gem 'elixir-toolkit-theme-plugins', '~> 1.1.0'
-gem "webrick", "~> 1.9.1"
+gem "elixir-toolkit-theme-plugins", "1.2.0"
+gem "webrick", "~> 1.9.2"
 gem "jekyll", "~> 4.4.1"
 gem "jemoji", "~> 0.13.0"
 gem "kramdown-parser-gfm", "~> 1.1"
-gem 'jekyll-octicons'
 gem "csv"
 
 group :jekyll_plugins do
-  gem 'jekyll-redirect-from', '~> 0.16.0'
-  gem 'jekyll-sitemap', '~> 1.4'
-  gem 'jekyll-github-metadata', '~> 2.16.0'
-  gem 'jekyll-relative-links', '~> 0.7.0'
-  gem 'jekyll-seo-tag', '~> 2.8'
-  gem 'jekyll-remote-theme', '~> 0.4.3'
-  gem 'jekyll-sass-converter', '~> 2.0'
-  gem 'jekyll-scholar', '~> 7.1.3'
-  gem 'jekyll-octicons'
+  gem "jekyll-redirect-from", "~> 0.16.0"
+  gem "jekyll-sitemap", "~> 1.4"
+  gem "jekyll-github-metadata", "~> 2.16.0"
+  gem "jekyll-relative-links", "~> 0.8.0"
+  gem "jekyll-seo-tag", "~> 2.8"
+  gem "jekyll-remote-theme", "~> 0.5.2"
+  gem "jekyll-sass-converter", "~> 3.1"
+  gem "jekyll-scholar", "~> 7.1.3"
+  gem "jekyll-octicons"
 end

--- a/_config.yml
+++ b/_config.yml
@@ -22,8 +22,6 @@ dsw_deep_link_prefix: https://researchers.dsw.elixir-europe.org/knowledge-models
 
 theme_variables:
   dev-info-banner: true
-  topnav:
-    theme: dark
   theme_color: c23669
   fonts:
     - https://fonts.googleapis.com/css2?family=Exo+2:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,400&display=swap

--- a/_sass/_custom_classes.scss
+++ b/_sass/_custom_classes.scss
@@ -44,7 +44,7 @@
     }
     #sidebar>nav .sidebar-title-wrapper {
         background: $white;
-}
+    }
 }
 
 #main {
@@ -170,10 +170,6 @@ section#search-section {
 
 .navbar-nav .nav-item > a {
     white-space: nowrap;
-    &.active {
-        background-color: $primary;
-        border-radius: $border-radius;
-    }
 }
 
 /*-----Better tools-----*/
@@ -184,48 +180,73 @@ section#search-section {
 
 /*-----New Icons-----*/
 
-// Calender
-i.far.fa-calendar {
+.landingpage #search-label {
+    background-color: $white;
+}
+
+i.icon-search {
+    display: inline-block;
+    background: url("../img/section-icons/search.svg") center no-repeat;
+    width: 30px;
+    height: 30px;
+
+    &:before {
+        content: "" !important;
+    }
+}
+
+// Calendar
+.news-timeline-date i.icon-calendar,
+.event-card-icon i.icon-calendar {
+    display: inline-block;
     background: url("../img/section-icons/calendar.svg") center no-repeat;
     width: 17px;
     height: 17px;
     margin-bottom: -2px;
+
     &:before {
         content: "";
     }
 }
 
-i.fa-solid.fa-map-marker-alt {
+// Map pin
+.event-card-date i.icon-map-pin {
+    display: inline-block;
     background: url("../img/section-icons/pin.svg") center no-repeat;
     width: 17px;
     height: 17px;
     margin-bottom: -2px;
+
     &:before {
         content: "";
     }
 }
 
-// Fork
-i.fa-solid.fa-code-branch {
+// Git branch
+.news-timeline-date i.icon-git-branch {
+    display: inline-block;
     background: url("../img/section-icons/git.svg") center no-repeat;
     width: 20px;
     height: 20px;
     margin-bottom: -2.5px;
+
     &:before {
         content: "";
     }
 }
 
-// Search
-.landingpage #search-label {
-    background-color: $white;
+/*-----News and events-----*/
+
+.news-timeline-date {
+    .news-metadata-item {
+        flex: 0 0 auto;
+        white-space: nowrap;
+    }
 }
-i.fa-solid.fa-magnifying-glass {
-    background: url("../img/section-icons/search.svg") center no-repeat;
-    width: 30px;
-    height: 30px;
-    &:before {
-        content: "";
+
+.event-card-date {
+    time {
+        white-space: nowrap;
     }
 }
 

--- a/_sass/_custom_classes.scss
+++ b/_sass/_custom_classes.scss
@@ -88,11 +88,17 @@
 /* -----Homepage----- */
 
 .landingpage, .ways-to-contribute  {
-    .card {
-        &:hover {
+    .card,
+    .landing-tile {
+        transition: $transition-base;
+
+        &:hover,
+        &:focus-within {
             box-shadow: $box-shadow;
         }
+    }
 
+    .card {
         .card-img-top {
             width: unset;
             padding: $card-spacer-x $card-spacer-x 0 $card-spacer-x;

--- a/_sass/_custom_variables.scss
+++ b/_sass/_custom_variables.scss
@@ -4,31 +4,30 @@ $font-family-theme: "Exo 2", sans-serif;
 
 /*-----Top navigation-----*/
 $topnav-bg: $dark;
+$topnav-title-color: $white;
 $topnav-brand-height: 40px;
-
-/*-----More information tiles-----*/
-$info-card-bg: $light;
-$info-card-color: $dark;
-$info-card-bg-hover: $primary;
-$info-card-color-hover: $white;
+$topnav-link-color: $white;
+$topnav-link-color-active: $white;
+$topnav-link-bg-active: $primary;
+$topnav-break-color: rgba($white, 0.50);
 
 /*-----Sidebar-----*/
 $sidebar-title-bg: $light;
+$sidebar-link-bg-active: rgba($primary, 0.1);
 
 /*-----Page metadata-----*/
 $page-metadata-bg: rgba($blue, 0.1);
 
 /*-----Section navigation tiles-----*/
-$nav-card-bg: $light;
-$nav-card-color: $dark;
 $nav-card-bg-hover: $light;
-$nav-card-color-hover: $dark;
+$nav-card-arrow-bg: rgba($primary, 0.1);
 
 /*-----Footer-----*/
 $footer-bg: $dark;
 $footer-color: $white;
 $footer-link-color: $white;
+$footer-link-color-hover: $primary;
 $footer-copyright-bg: #00000033;
+$footer-ett: $white;
 
-/*-----Events & news-----*/
-$news-border-color: $dark;
+

--- a/index.html
+++ b/index.html
@@ -23,7 +23,7 @@ layout: none
                     <div class="position-relative">
                         <div class="d-flex justify-content-center">
                             <form role="search" class="input-group">
-                                <span class="input-group-text" id="search-label"><i class="fa-solid fa-magnifying-glass"></i></span>
+                                <span class="input-group-text" id="search-label"><i class="icon-search"></i></span>
                                 <input type="search" id="search-input" class="search-input form-control form-control-lg bg-white" tabindex="0"
                                     placeholder="Search {{ site.title }}" aria-label="Search {{ site.title }}" autocomplete="off">
                             </form>

--- a/index.html
+++ b/index.html
@@ -116,7 +116,7 @@ layout: none
                 {%- assign tools = site.data.tool_and_resource_list -%}
                 <div class="row row-cols-1 row-cols-sm-2 row-cols-lg-3 g-4 mb-3">
                     <div class="col">
-                        <div class="bg-white d-flex align-items-center rounded p-3 text-center h-100">
+                        <div class="landing-tile bg-white d-flex align-items-center rounded p-3 text-center h-100">
                             <div class="row g-1 flex-grow-1">
                                 <div class="col-7">
                                     <span class="count-number text-primary">{{allcontributors.size}}</span>
@@ -130,7 +130,7 @@ layout: none
                         </div>
                     </div>
                     <div class="col">
-                        <div class="bg-white d-flex align-items-center rounded p-3 text-center h-100">
+                        <div class="landing-tile bg-white d-flex align-items-center rounded p-3 text-center h-100">
                             {%- assign national_tools = 0 %}
                             {%- assign country_pages = site.pages | where: "type", "national_resources" | where:
                             "search_exclude", false %}
@@ -150,7 +150,7 @@ layout: none
                         </div>
                     </div>
                     <div class="col">
-                        <div class="bg-white d-flex align-items-center rounded p-3 text-center h-100">
+                        <div class="landing-tile bg-white d-flex align-items-center rounded p-3 text-center h-100">
                             {%- assign content_pages = site.pages | where: "search_exclude", false %}
                             <div class="row g-1 flex-grow-1">
                                 <div class="col-7">


### PR DESCRIPTION
- Update RDMkit theme overrides for the current ELIXIR Toolkit theme `main` branch
- Replace obsolete Font Awesome-based search/news/event overrides with the Lucide selectors used by theme `main`
- Keep RDMkit custom SVG icon styling for search, news, and event metadata
- Prevent news/event metadata such as dates and PR links from wrapping awkwardly
- Move top navigation, sidebar active state, nav card arrow, metadata, and footer styling to the current Sass variable names
- Remove obsolete theme settings and no-longer-used custom Sass variables
- Align the Gemfile dependency constraints with the ELIXIR Toolkit theme `main` Gemfile
