### PR TITLE
Fix Dev Container permissions and local Jekyll build

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,4 +1,36 @@
 {
     "name": "RDMkit",
-    "image": "mcr.microsoft.com/vscode/devcontainers/jekyll:latest"
+    "image": "mcr.microsoft.com/vscode/devcontainers/jekyll:latest",
+
+    // The image ships a root-owned GEM_HOME at /usr/local/bundle, so gem installs
+    // as the non-root "vscode" user fail with Bundler::PermissionError. Point
+    // Bundler at a user-owned directory instead.
+    "containerEnv": {
+        "GEM_HOME": "/home/vscode/.gem",
+        "BUNDLE_PATH": "/home/vscode/.gem",
+        "BUNDLE_APP_CONFIG": "/home/vscode/.gem",
+
+        // jekyll-github-metadata derives the repository name by shelling out to
+        // "git remote", which is unreliable on a bind-mounted workspace, and is
+        // skipped altogether when JEKYLL_ENV=production (as "make build" sets).
+        // Supplying the name directly is what the CI workflows do as well.
+        "PAGES_REPO_NWO": "elixir-europe/rdmkit"
+    },
+    "remoteEnv": {
+        "PATH": "/home/vscode/.gem/bin:${containerEnv:PATH}"
+    },
+
+    // Keep installed gems in a named volume so they survive container rebuilds
+    // and are not written into the (bind-mounted, slower) workspace.
+    "mounts": [
+        "source=rdmkit-gems,target=/home/vscode/.gem,type=volume"
+    ],
+
+    // A fresh named volume is created root-owned; hand it to vscode before use.
+    // The workspace is a bind mount whose owner uid git may read as root, which
+    // makes it refuse to run there ("detected dubious ownership").
+    "postCreateCommand": "sudo chown -R vscode:vscode /home/vscode/.gem && git config --global --add safe.directory ${containerWorkspaceFolder} && bundle install",
+
+    "forwardPorts": [4000, 35729],
+    "remoteUser": "vscode"
 }


### PR DESCRIPTION
With a recent vscode-insiders version and the stock devcontainer, I was not able to build the RDMkit pages without errors related to access rights.

The jekyll devcontainer image sets GEM_HOME to the root-owned /usr/local/bundle, so gem installs as the non-root vscode user fail with Bundler::PermissionError. Point Bundler at a user-owned directory backed by a named volume instead.

I also had to mark the workspace as a safe git directory and set PAGES_REPO_NWO. The workspace is a bind mount whose owner uid git can read as root, which makes it refuse to run there; jekyll-github-metadata then finds no origin remote and the build fails. Supplying the repository name directly is what the CI workflows already do, and it is also required for "make build", which sets JEKYLL_ENV=production and so skips the git fallback entirely.

The devcontainer exposes port 4000 which allows to access the development version of the RDMkit page when served with `make dev`